### PR TITLE
HeaderSlices: preverified headers downloader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ bytes = { package = "lifetimed-bytes", git = "https://github.com/vorot93/lifetim
 bytesize = "1"
 clap = "2"
 console-subscriber = { git = "https://github.com/tokio-rs/console" }
+crossterm = { version = "0.20", optional = true }
 derive_more = "0.99"
 ethereum-interfaces = { git = "https://github.com/ledgerwatch/interfaces", features = [
     "remotekv",

--- a/src/changeset/storage.rs
+++ b/src/changeset/storage.rs
@@ -169,7 +169,7 @@ where
     Ok(None)
 }
 
-#[cfg(test)]
+#[cfg(test_storage)]
 mod tests {
     use super::*;
     use crate::{

--- a/src/changeset/storage.rs
+++ b/src/changeset/storage.rs
@@ -169,7 +169,7 @@ where
     Ok(None)
 }
 
-#[cfg(test_storage)]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::{

--- a/src/downloader/downloader_impl.rs
+++ b/src/downloader/downloader_impl.rs
@@ -1,15 +1,23 @@
 use crate::downloader::{
-    block_id,
     chain_config::{ChainConfig, ChainsConfig},
-    messages::{EthMessageId, GetBlockHeadersMessage, GetBlockHeadersMessageParams, Message},
+    headers::{
+        fetch_receive_stage::FetchReceiveStage, fetch_request_stage::FetchRequestStage,
+        header_slices::HeaderSlices, refill_stage::RefillStage, retry_stage::RetryStage,
+        save_stage::SaveStage, verify_stage::VerifyStage,
+    },
     opts::Opts,
     sentry_client,
-    sentry_client::{PeerFilter, SentryClient},
+    sentry_client::SentryClient,
     sentry_client_impl::SentryClientImpl,
     sentry_client_reactor::SentryClientReactor,
 };
-use tokio_stream::StreamExt;
+use futures_core::Stream;
+use parking_lot::RwLock;
+use std::{pin::Pin, rc::Rc, sync::Arc};
+use tokio_stream::{StreamExt, StreamMap};
 use tracing::*;
+
+type StageStream = Pin<Box<dyn Stream<Item = anyhow::Result<()>>>>;
 
 pub struct Downloader {
     opts: Opts,
@@ -41,26 +49,91 @@ impl Downloader {
 
         sentry_client.set_status(status).await?;
 
-        let mut sentry = SentryClientReactor::new(sentry_client);
-        sentry.start();
+        let mut sentry_reactor = SentryClientReactor::new(sentry_client);
+        sentry_reactor.start();
 
-        let message = Message::GetBlockHeaders(GetBlockHeadersMessage {
-            request_id: 1,
-            params: GetBlockHeadersMessageParams {
-                start_block: block_id::BlockId::Number(123),
-                limit: 5,
-                skip: 0,
-                reverse: 0,
-            },
+        let header_slices = Arc::new(HeaderSlices::new(50 << 20 /* 50 Mb */));
+        let sentry = Arc::new(RwLock::new(sentry_reactor));
+
+        // Downloading happens with several stages where
+        // each of the stages processes blocks in one status,
+        // and updates them to proceed to the next status.
+        // All stages runs in parallel,
+        // although most of the time only one of the stages is actively running,
+        // while the others are waiting for the status updates or timeouts.
+
+        let fetch_request_stage =
+            FetchRequestStage::new(Arc::clone(&header_slices), Arc::clone(&sentry));
+
+        let fetch_receive_stage =
+            FetchReceiveStage::new(Arc::clone(&header_slices), Arc::clone(&sentry));
+        let fetch_receive_stage = Rc::new(fetch_receive_stage);
+        let fetch_receive_stage_ref = Rc::clone(&fetch_receive_stage);
+
+        let retry_stage = RetryStage::new(Arc::clone(&header_slices));
+
+        let verify_stage = VerifyStage::new(Arc::clone(&header_slices));
+
+        let save_stage = SaveStage::new(Arc::clone(&header_slices));
+
+        let refill_stage = RefillStage::new(Arc::clone(&header_slices));
+
+        let fetch_request_stage_stream: StageStream = Box::pin(async_stream::stream! {
+            loop {
+                yield fetch_request_stage.execute().await;
+            }
         });
-        sentry.send_message(message, PeerFilter::All).await?;
+        let fetch_receive_stage_stream: StageStream = Box::pin(async_stream::stream! {
+            loop {
+                yield fetch_receive_stage.execute().await;
+            }
+        });
+        let retry_stage_stage_stream: StageStream = Box::pin(async_stream::stream! {
+            loop {
+                yield retry_stage.execute().await;
+            }
+        });
+        let verify_stage_stage_stream: StageStream = Box::pin(async_stream::stream! {
+            loop {
+                yield verify_stage.execute().await;
+            }
+        });
+        let save_stage_stage_stream: StageStream = Box::pin(async_stream::stream! {
+            loop {
+                yield save_stage.execute().await;
+            }
+        });
+        let refill_stage_stage_stream: StageStream = Box::pin(async_stream::stream! {
+            loop {
+                yield refill_stage.execute().await;
+            }
+        });
 
-        let mut stream = sentry.receive_messages(EthMessageId::BlockHeaders)?;
-        while let Some(message) = stream.next().await {
-            info!("incoming message: {:?}", message.eth_id());
+        let mut stream = StreamMap::<&str, StageStream>::new();
+        stream.insert("fetch_request_stage_stream", fetch_request_stage_stream);
+        stream.insert("fetch_receive_stage_stream", fetch_receive_stage_stream);
+        stream.insert("retry_stage_stage_stream", retry_stage_stage_stream);
+        stream.insert("verify_stage_stage_stream", verify_stage_stage_stream);
+        stream.insert("save_stage_stage_stream", save_stage_stage_stream);
+        stream.insert("refill_stage_stage_stream", refill_stage_stage_stream);
+
+        while let Some((key, result)) = stream.next().await {
+            if result.is_err() {
+                error!("Downloader headers {} failure: {:?}", key, result);
+                break;
+            }
+
+            if !fetch_receive_stage_ref.can_proceed() {
+                break;
+            }
+
+            header_slices.notify_status_watchers();
         }
 
-        sentry.stop().await?;
+        {
+            let mut sentry_reactor = sentry.write();
+            sentry_reactor.stop().await?;
+        }
 
         Ok(())
     }

--- a/src/downloader/headers/fetch_receive_stage.rs
+++ b/src/downloader/headers/fetch_receive_stage.rs
@@ -1,0 +1,130 @@
+use crate::{
+    downloader::{
+        headers::{
+            header_slices,
+            header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices},
+        },
+        messages::{BlockHeadersMessage, EthMessageId, Message},
+        sentry_client_reactor::SentryClientReactor,
+    },
+    models::BlockHeader as Header,
+};
+use futures_core::Stream;
+use parking_lot::RwLock;
+use std::{
+    cell::{Cell, RefCell},
+    ops::DerefMut,
+    pin::Pin,
+    sync::Arc,
+};
+use tokio_stream::StreamExt;
+use tracing::*;
+
+type BlockHeadersMessageStream = Pin<Box<dyn Stream<Item = BlockHeadersMessage> + Send>>;
+
+/// Receives the slices, and sets Downloaded status.
+pub struct FetchReceiveStage {
+    header_slices: Arc<HeaderSlices>,
+    sentry: Arc<RwLock<SentryClientReactor>>,
+    is_over: Cell<bool>,
+    message_stream: RefCell<Option<RefCell<BlockHeadersMessageStream>>>,
+}
+
+impl FetchReceiveStage {
+    pub fn new(header_slices: Arc<HeaderSlices>, sentry: Arc<RwLock<SentryClientReactor>>) -> Self {
+        Self {
+            header_slices,
+            sentry,
+            is_over: Cell::new(false),
+            message_stream: RefCell::new(None),
+        }
+    }
+
+    pub async fn execute(&self) -> anyhow::Result<()> {
+        debug!("FetchReceiveStage: start");
+        if self.message_stream.borrow().is_none() {
+            let message_stream = self.receive_headers()?;
+            *self.message_stream.borrow_mut() = Some(RefCell::new(message_stream));
+        }
+
+        let message_stream_opt = self.message_stream.borrow();
+        let mut message_stream = message_stream_opt.as_ref().unwrap().borrow_mut();
+        let message_result = message_stream.next().await;
+        match message_result {
+            Some(message) => self.on_headers(message.headers),
+            None => self.is_over.set(true),
+        }
+        debug!("FetchReceiveStage: done");
+        Ok(())
+    }
+
+    pub fn can_proceed(&self) -> bool {
+        let request_statuses = &[HeaderSliceStatus::Empty, HeaderSliceStatus::Waiting];
+        let cant_receive_more =
+            self.is_over.get() && self.header_slices.has_one_of_statuses(request_statuses);
+        !cant_receive_more
+    }
+
+    fn on_headers(&self, headers: Vec<Header>) {
+        debug!("FetchReceiveStage: received a headers slice");
+
+        if headers.len() < header_slices::HEADER_SLICE_SIZE {
+            warn!(
+                "FetchReceiveStage got a headers slice of a smaller size: {}",
+                headers.len()
+            );
+            return;
+        }
+        let start_block_num = headers[0].number;
+
+        self.header_slices.find(
+            start_block_num,
+            move |slice_lock_opt: Option<&RwLock<HeaderSlice>>| {
+                self.update_slice(slice_lock_opt, headers, start_block_num);
+            },
+        );
+    }
+
+    fn update_slice(
+        &self,
+        slice_lock_opt: Option<&RwLock<HeaderSlice>>,
+        headers: Vec<Header>,
+        start_block_num: u64,
+    ) {
+        match slice_lock_opt {
+            Some(slice_lock) => {
+                let mut slice = slice_lock.write();
+                match slice.status {
+                    HeaderSliceStatus::Waiting => {
+                        slice.headers = Some(headers);
+                        self.header_slices
+                            .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Downloaded);
+                    }
+                    unexpected_status => {
+                        warn!("FetchReceiveStage ignores a headers slice that we didn't request starting at: {}; status = {:?}", start_block_num, unexpected_status);
+                    }
+                }
+            }
+            None => {
+                warn!(
+                    "FetchReceiveStage ignores a headers slice that we didn't request starting at: {}",
+                    start_block_num
+                );
+            }
+        }
+    }
+
+    fn receive_headers(&self) -> anyhow::Result<BlockHeadersMessageStream> {
+        let in_stream = self
+            .sentry
+            .read()
+            .receive_messages(EthMessageId::BlockHeaders)?;
+
+        let out_stream = in_stream.map(|message| match message {
+            Message::BlockHeaders(message) => message,
+            _ => panic!("unexpected type {:?}", message.eth_id()),
+        });
+
+        Ok(Box::pin(out_stream))
+    }
+}

--- a/src/downloader/headers/fetch_request_stage.rs
+++ b/src/downloader/headers/fetch_request_stage.rs
@@ -1,0 +1,108 @@
+use crate::downloader::{
+    block_id,
+    headers::{
+        header_slices,
+        header_slices::{HeaderSliceStatus, HeaderSlices},
+    },
+    messages::{GetBlockHeadersMessage, GetBlockHeadersMessageParams, Message},
+    sentry_client::PeerFilter,
+    sentry_client_reactor::{SendMessageError, SentryClientReactor},
+};
+use parking_lot::{lock_api::RwLockUpgradableReadGuard, RwLock};
+use std::{
+    cell::{Cell, RefCell},
+    ops::DerefMut,
+    sync::Arc,
+};
+use tokio::sync::watch;
+use tracing::*;
+
+/// Sends requests to P2P via sentry to get the slices. Slices become Waiting.
+pub struct FetchRequestStage {
+    header_slices: Arc<HeaderSlices>,
+    sentry: Arc<RwLock<SentryClientReactor>>,
+    last_request_id: Cell<u64>,
+    pending_watch: RefCell<watch::Receiver<usize>>,
+}
+
+impl FetchRequestStage {
+    pub fn new(header_slices: Arc<HeaderSlices>, sentry: Arc<RwLock<SentryClientReactor>>) -> Self {
+        let pending_watch = header_slices.watch_status_changes(HeaderSliceStatus::Empty);
+
+        Self {
+            header_slices,
+            sentry,
+            last_request_id: Cell::new(0),
+            pending_watch: RefCell::new(pending_watch),
+        }
+    }
+
+    fn pending_count(&self) -> usize {
+        self.header_slices
+            .count_slices_in_status(HeaderSliceStatus::Empty)
+    }
+
+    pub async fn execute(&self) -> anyhow::Result<()> {
+        debug!("FetchRequestStage: start");
+        if self.pending_count() == 0 {
+            debug!("FetchRequestStage: waiting pending");
+            let mut watch = self.pending_watch.borrow_mut();
+            while *watch.borrow_and_update() == 0 {
+                watch.changed().await?;
+            }
+            debug!("FetchRequestStage: waiting pending done");
+        }
+
+        info!(
+            "FetchRequestStage: requesting {} slices",
+            self.pending_count()
+        );
+        self.request_pending()?;
+        debug!("FetchRequestStage: done");
+        Ok(())
+    }
+
+    fn request_pending(&self) -> anyhow::Result<()> {
+        self.header_slices.for_each(|slice_lock| {
+            let slice = slice_lock.upgradable_read();
+            if slice.status == HeaderSliceStatus::Empty {
+                let mut request_id = self.last_request_id.get();
+                request_id += 1;
+                self.last_request_id.set(request_id);
+
+                let block_num = slice.start_block_num;
+                let limit = header_slices::HEADER_SLICE_SIZE as u64 + 1;
+
+                let result = self.request(request_id, block_num, limit);
+                match result {
+                    Err(error) => match error.downcast_ref::<SendMessageError>() {
+                        Some(SendMessageError::SendQueueFull) => return Some(Ok(())),
+                        Some(SendMessageError::ReactorStopped) => return Some(Err(error)),
+                        None => return Some(Err(error)),
+                    },
+                    Ok(_) => {
+                        let mut slice = RwLockUpgradableReadGuard::upgrade(slice);
+                        self.header_slices
+                            .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Waiting);
+                    }
+                }
+            }
+            None
+        })
+    }
+
+    fn request(&self, request_id: u64, block_num: u64, limit: u64) -> anyhow::Result<()> {
+        let message = GetBlockHeadersMessage {
+            request_id,
+            params: GetBlockHeadersMessageParams {
+                start_block: block_id::BlockId::Number(block_num),
+                limit,
+                skip: 0,
+                reverse: 0,
+            },
+        };
+        self.sentry
+            .read()
+            .try_send_message(Message::GetBlockHeaders(message), PeerFilter::Random(1))
+    }
+}

--- a/src/downloader/headers/mod.rs
+++ b/src/downloader/headers/mod.rs
@@ -1,0 +1,8 @@
+pub mod header_slices;
+
+pub mod fetch_receive_stage;
+pub mod fetch_request_stage;
+pub mod refill_stage;
+pub mod retry_stage;
+pub mod save_stage;
+pub mod verify_stage;

--- a/src/downloader/headers/mod.rs
+++ b/src/downloader/headers/mod.rs
@@ -6,3 +6,13 @@ pub mod refill_stage;
 pub mod retry_stage;
 pub mod save_stage;
 pub mod verify_stage;
+
+#[cfg(feature = "crossterm")]
+pub mod ui_crossterm;
+#[cfg(feature = "crossterm")]
+pub use ui_crossterm::HeaderSlicesView;
+
+#[cfg(not(feature = "crossterm"))]
+pub mod ui_tracing;
+#[cfg(not(feature = "crossterm"))]
+pub use ui_tracing::HeaderSlicesView;

--- a/src/downloader/headers/refill_stage.rs
+++ b/src/downloader/headers/refill_stage.rs
@@ -1,0 +1,49 @@
+use crate::downloader::headers::header_slices::{HeaderSliceStatus, HeaderSlices};
+use std::{cell::RefCell, sync::Arc};
+use tokio::sync::watch;
+use tracing::*;
+
+/// Forgets the Saved slices from memory, and creates more Empty slices
+/// until we reach the end of pre-verified chain.
+pub struct RefillStage {
+    header_slices: Arc<HeaderSlices>,
+    pending_watch: RefCell<watch::Receiver<usize>>,
+}
+
+impl RefillStage {
+    pub fn new(header_slices: Arc<HeaderSlices>) -> Self {
+        let pending_watch = header_slices.watch_status_changes(HeaderSliceStatus::Saved);
+
+        Self {
+            header_slices,
+            pending_watch: RefCell::new(pending_watch),
+        }
+    }
+
+    fn pending_count(&self) -> usize {
+        self.header_slices
+            .count_slices_in_status(HeaderSliceStatus::Saved)
+    }
+
+    pub async fn execute(&self) -> anyhow::Result<()> {
+        debug!("RefillStage: start");
+        if self.pending_count() == 0 {
+            debug!("RefillStage: waiting pending");
+            let mut watch = self.pending_watch.borrow_mut();
+            while *watch.borrow_and_update() == 0 {
+                watch.changed().await?;
+            }
+            debug!("RefillStage: waiting pending done");
+        }
+
+        info!("RefillStage: refilling {} slices", self.pending_count());
+        self.refill_pending();
+        debug!("RefillStage: done");
+        Ok(())
+    }
+
+    fn refill_pending(&self) {
+        self.header_slices.remove(HeaderSliceStatus::Saved);
+        self.header_slices.refill();
+    }
+}

--- a/src/downloader/headers/retry_stage.rs
+++ b/src/downloader/headers/retry_stage.rs
@@ -1,0 +1,62 @@
+use crate::downloader::headers::header_slices::{HeaderSliceStatus, HeaderSlices};
+use parking_lot::lock_api::RwLockUpgradableReadGuard;
+use std::{cell::RefCell, ops::DerefMut, sync::Arc};
+use tokio::sync::watch;
+use tracing::*;
+
+/// Handles timeouts. If a slice is Waiting for too long, we need to request it again.
+/// Status is updated to Empty (the slice will be processed by the FetchRequestStage again).
+pub struct RetryStage {
+    header_slices: Arc<HeaderSlices>,
+    pending_watch: RefCell<watch::Receiver<usize>>,
+}
+
+impl RetryStage {
+    pub fn new(header_slices: Arc<HeaderSlices>) -> Self {
+        let pending_watch = header_slices.watch_status_changes(HeaderSliceStatus::Waiting);
+
+        Self {
+            header_slices,
+            pending_watch: RefCell::new(pending_watch),
+        }
+    }
+
+    fn pending_count(&self) -> usize {
+        self.header_slices
+            .count_slices_in_status(HeaderSliceStatus::Waiting)
+    }
+
+    pub async fn execute(&self) -> anyhow::Result<()> {
+        debug!("RetryStage: start");
+        if self.pending_count() == 0 {
+            debug!("RetryStage: waiting pending");
+            let mut watch = self.pending_watch.borrow_mut();
+            while *watch.borrow_and_update() == 0 {
+                watch.changed().await?;
+            }
+            debug!("RetryStage: waiting pending done");
+        }
+
+        // retry if nothing happens for 10 sec
+        // TODO: ideally need to respect the time when Waiting was started,
+        //     and only reset those that wait for too long
+        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+
+        info!("RetryStage: resetting {} slices", self.pending_count());
+        self.reset_pending()?;
+        debug!("RetryStage: done");
+        Ok(())
+    }
+
+    fn reset_pending(&self) -> anyhow::Result<()> {
+        self.header_slices.for_each(|slice_lock| {
+            let slice = slice_lock.upgradable_read();
+            if slice.status == HeaderSliceStatus::Waiting {
+                let mut slice = RwLockUpgradableReadGuard::upgrade(slice);
+                self.header_slices
+                    .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Empty);
+            }
+            None
+        })
+    }
+}

--- a/src/downloader/headers/save_stage.rs
+++ b/src/downloader/headers/save_stage.rs
@@ -1,0 +1,66 @@
+use crate::downloader::headers::header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices};
+use parking_lot::lock_api::RwLockUpgradableReadGuard;
+use std::{cell::RefCell, ops::DerefMut, sync::Arc};
+use tokio::sync::watch;
+use tracing::*;
+
+/// Saves slices into the database, and sets Saved status.
+pub struct SaveStage {
+    header_slices: Arc<HeaderSlices>,
+    pending_watch: RefCell<watch::Receiver<usize>>,
+}
+
+impl SaveStage {
+    pub fn new(header_slices: Arc<HeaderSlices>) -> Self {
+        let pending_watch = header_slices.watch_status_changes(HeaderSliceStatus::Verified);
+
+        Self {
+            header_slices,
+            pending_watch: RefCell::new(pending_watch),
+        }
+    }
+
+    fn pending_count(&self) -> usize {
+        self.header_slices
+            .count_slices_in_status(HeaderSliceStatus::Verified)
+    }
+
+    pub async fn execute(&self) -> anyhow::Result<()> {
+        debug!("SaveStage: start");
+        if self.pending_count() == 0 {
+            debug!("SaveStage: waiting pending");
+            let mut watch = self.pending_watch.borrow_mut();
+            while *watch.borrow_and_update() == 0 {
+                watch.changed().await?;
+            }
+            debug!("SaveStage: waiting pending done");
+        }
+
+        info!("SaveStage: saving {} slices", self.pending_count());
+        self.save_pending().await?;
+        debug!("SaveStage: done");
+        Ok(())
+    }
+
+    async fn save_pending(&self) -> anyhow::Result<()> {
+        self.header_slices.for_each(|slice_lock| {
+            let slice = slice_lock.upgradable_read();
+            if slice.status == HeaderSliceStatus::Verified {
+                let save_result = self.save_slice(&slice);
+                if save_result.is_err() {
+                    return Some(save_result);
+                }
+
+                let mut slice = RwLockUpgradableReadGuard::upgrade(slice);
+                self.header_slices
+                    .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Saved);
+            }
+            None
+        })
+    }
+
+    fn save_slice(&self, _slice: &HeaderSlice) -> anyhow::Result<()> {
+        // TODO: save verified headers to the DB
+        Ok(())
+    }
+}

--- a/src/downloader/headers/ui_crossterm.rs
+++ b/src/downloader/headers/ui_crossterm.rs
@@ -1,0 +1,89 @@
+use crate::downloader::{
+    headers::header_slices::{HeaderSliceStatus, HeaderSlices},
+    ui_view::UIView,
+};
+use crossterm::{cursor, style, terminal, QueueableCommand};
+use std::{
+    io::{stdout, Write},
+    sync::Arc,
+};
+
+pub struct HeaderSlicesView {
+    header_slices: Arc<HeaderSlices>,
+}
+
+impl HeaderSlicesView {
+    pub fn new(header_slices: Arc<HeaderSlices>) -> Self {
+        Self { header_slices }
+    }
+}
+
+impl UIView for HeaderSlicesView {
+    fn draw(&self) -> anyhow::Result<()> {
+        let statuses = self.header_slices.clone_statuses();
+        let counters = self.header_slices.status_counters();
+        let min_block_num = self.header_slices.min_block_num();
+        let max_block_num = self.header_slices.max_block_num();
+
+        let mut stdout = stdout();
+
+        // save the logging position
+        stdout.queue(cursor::SavePosition {})?;
+
+        // draw at the top of the window
+        stdout.queue(cursor::MoveTo(0, 0))?;
+        stdout.queue(terminal::EnableLineWrap {})?;
+
+        // overall progress
+        let progress_desc = std::format!(
+            "downloading headers {} - {} ...",
+            min_block_num,
+            max_block_num
+        );
+        stdout.queue(style::Print(progress_desc))?;
+        stdout.queue(terminal::Clear(terminal::ClearType::UntilNewLine))?;
+        stdout.queue(cursor::MoveToNextLine(1))?;
+
+        // slice statuses
+        for status in statuses {
+            let c = char::from(status);
+            stdout.queue(style::Print(c))?;
+        }
+        stdout.queue(terminal::Clear(terminal::ClearType::UntilNewLine))?;
+        stdout.queue(cursor::MoveToNextLine(1))?;
+
+        // counters
+        stdout.queue(style::Print(format_counters(counters)))?;
+        stdout.queue(terminal::Clear(terminal::ClearType::UntilNewLine))?;
+        stdout.queue(cursor::MoveToNextLine(1))?;
+
+        // delimiter line
+        stdout.queue(terminal::Clear(terminal::ClearType::CurrentLine))?;
+        stdout.queue(style::Print("\n"))?;
+
+        stdout.queue(cursor::RestorePosition {})?;
+        stdout.flush()?;
+
+        Ok(())
+    }
+}
+
+fn format_counters(counters: Vec<(HeaderSliceStatus, usize)>) -> String {
+    let mut line = String::new();
+    for (status, count) in counters {
+        line.push_str(std::format!("({}): {}; ", char::from(status), count).as_str());
+    }
+    line
+}
+
+impl From<HeaderSliceStatus> for char {
+    fn from(status: HeaderSliceStatus) -> Self {
+        match status {
+            HeaderSliceStatus::Empty => '-',
+            HeaderSliceStatus::Waiting => '<',
+            HeaderSliceStatus::Downloaded => '.',
+            HeaderSliceStatus::Verified => '#',
+            HeaderSliceStatus::Saved => '+',
+        }
+    }
+}

--- a/src/downloader/headers/ui_tracing.rs
+++ b/src/downloader/headers/ui_tracing.rs
@@ -1,0 +1,20 @@
+use crate::downloader::{headers::header_slices::HeaderSlices, ui_view::UIView};
+use std::sync::Arc;
+use tracing::*;
+
+pub struct HeaderSlicesView {
+    header_slices: Arc<HeaderSlices>,
+}
+
+impl HeaderSlicesView {
+    pub fn new(header_slices: Arc<HeaderSlices>) -> Self {
+        Self { header_slices }
+    }
+}
+
+impl UIView for HeaderSlicesView {
+    fn draw(&self) -> anyhow::Result<()> {
+        info!("downloading headers...");
+        Ok(())
+    }
+}

--- a/src/downloader/headers/verify_stage.rs
+++ b/src/downloader/headers/verify_stage.rs
@@ -1,0 +1,70 @@
+use crate::downloader::headers::header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices};
+use parking_lot::lock_api::RwLockUpgradableReadGuard;
+use std::{cell::RefCell, ops::DerefMut, sync::Arc};
+use tokio::sync::watch;
+use tracing::*;
+
+/// Checks that block hashes are matching the expected ones and sets Verified status.
+pub struct VerifyStage {
+    header_slices: Arc<HeaderSlices>,
+    pending_watch: RefCell<watch::Receiver<usize>>,
+}
+
+impl VerifyStage {
+    pub fn new(header_slices: Arc<HeaderSlices>) -> Self {
+        let pending_watch = header_slices.watch_status_changes(HeaderSliceStatus::Downloaded);
+
+        Self {
+            header_slices,
+            pending_watch: RefCell::new(pending_watch),
+        }
+    }
+
+    fn pending_count(&self) -> usize {
+        self.header_slices
+            .count_slices_in_status(HeaderSliceStatus::Downloaded)
+    }
+
+    pub async fn execute(&self) -> anyhow::Result<()> {
+        debug!("VerifyStage: start");
+        if self.pending_count() == 0 {
+            debug!("VerifyStage: waiting pending");
+            let mut watch = self.pending_watch.borrow_mut();
+            while *watch.borrow_and_update() == 0 {
+                watch.changed().await?;
+            }
+            debug!("VerifyStage: waiting pending done");
+        }
+
+        info!("VerifyStage: verifying {} slices", self.pending_count());
+        self.verify_pending()?;
+        debug!("VerifyStage: done");
+        Ok(())
+    }
+
+    fn verify_pending(&self) -> anyhow::Result<()> {
+        self.header_slices.for_each(|slice_lock| {
+            let slice = slice_lock.upgradable_read();
+            if slice.status == HeaderSliceStatus::Downloaded {
+                let is_verified = self.verify_slice(&slice);
+
+                let mut slice = RwLockUpgradableReadGuard::upgrade(slice);
+                if is_verified {
+                    self.header_slices
+                        .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Verified);
+                } else {
+                    self.header_slices
+                        .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Empty);
+                    slice.headers = None;
+                    // TODO: penalize peer?
+                }
+            }
+            None
+        })
+    }
+
+    fn verify_slice(&self, _slice: &HeaderSlice) -> bool {
+        // TODO: verify hashes properly
+        rand::random::<u8>() < 224
+    }
+}

--- a/src/downloader/mod.rs
+++ b/src/downloader/mod.rs
@@ -15,4 +15,7 @@ mod downloader_tests;
 mod headers;
 mod sentry_client_reactor;
 
+mod ui_system;
+mod ui_view;
+
 pub use self::downloader_impl::Downloader;

--- a/src/downloader/mod.rs
+++ b/src/downloader/mod.rs
@@ -12,6 +12,7 @@ mod sentry_client_mock;
 
 #[cfg(test)]
 mod downloader_tests;
+mod headers;
 mod sentry_client_reactor;
 
 pub use self::downloader_impl::Downloader;

--- a/src/downloader/ui_system.rs
+++ b/src/downloader/ui_system.rs
@@ -1,0 +1,92 @@
+use crate::downloader::ui_view::UIView;
+use parking_lot::Mutex;
+use std::{sync::Arc, time::Duration};
+use tokio::{sync::mpsc, task::JoinHandle};
+use tracing::*;
+
+pub struct UISystem {
+    view_cell: Arc<Mutex<Option<Box<dyn UIView>>>>,
+    event_loop: Option<UISystemEventLoop>,
+    event_loop_handle: Option<JoinHandle<()>>,
+    stop_signal_sender: mpsc::Sender<()>,
+}
+
+struct UISystemEventLoop {
+    view_cell: Arc<Mutex<Option<Box<dyn UIView>>>>,
+    stop_signal_receiver: mpsc::Receiver<()>,
+}
+
+impl UISystem {
+    pub fn new() -> Self {
+        let view_cell = Arc::new(Mutex::new(None));
+
+        let (stop_signal_sender, stop_signal_receiver) = mpsc::channel::<()>(1);
+
+        let event_loop = UISystemEventLoop {
+            view_cell: Arc::clone(&view_cell),
+            stop_signal_receiver,
+        };
+
+        Self {
+            view_cell: Arc::clone(&view_cell),
+            event_loop: Some(event_loop),
+            event_loop_handle: None,
+            stop_signal_sender,
+        }
+    }
+
+    pub fn start(&mut self) {
+        let mut event_loop = self.event_loop.take().unwrap();
+        let handle = tokio::spawn(async move {
+            let result = event_loop.run().await;
+            if let Err(error) = result {
+                error!("UIEventLoop loop died: {:?}", error);
+            }
+        });
+        self.event_loop_handle = Some(handle);
+    }
+
+    pub async fn stop(&mut self) -> anyhow::Result<()> {
+        if let Some(handle) = self.event_loop_handle.take() {
+            self.send_stop_signal();
+            handle.await?;
+        }
+        Ok(())
+    }
+
+    fn send_stop_signal(&self) {
+        let result = self.stop_signal_sender.try_send(());
+        if result.is_err() {
+            warn!("UIEventLoop stop signal already sent or the loop died itself");
+        }
+    }
+
+    pub fn set_view(&self, view: Option<Box<dyn UIView>>) {
+        let mut view_cell = self.view_cell.lock();
+        *view_cell = view;
+    }
+}
+
+impl UISystemEventLoop {
+    async fn run(&mut self) -> anyhow::Result<()> {
+        loop {
+            tokio::select! {
+                _ = tokio::time::sleep(Duration::from_secs(1)) => {
+                    let view_cell = self.view_cell.lock();
+                    if let Some(view) = &*view_cell {
+                        _ = view.draw()?;
+                    }
+                }
+                Some(_) = self.stop_signal_receiver.recv() => {
+                    break;
+                }
+                else => {
+                    break;
+                }
+            }
+        }
+
+        info!("UISystem stopped");
+        Ok(())
+    }
+}

--- a/src/downloader/ui_view.rs
+++ b/src/downloader/ui_view.rs
@@ -1,0 +1,3 @@
+pub trait UIView: Send {
+    fn draw(&self) -> anyhow::Result<()>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
     destructuring_assignment,
     entry_insert,
     generic_associated_types,
+    linked_list_cursors,
     never_type,
     type_alias_impl_trait
 )]


### PR DESCRIPTION
The preverified headers are downloaded with a help of a HeaderSlices data structure.

HeaderSlices is a memory-limited buffer of HeaderSlice objects, each containing a sequential slice of headers.

Example of a HeaderSlices with max_slices = 3:

* HeaderSlice 0: headers 0-192
* HeaderSlice 1: headers 192-384
* HeaderSlice 2: headers 384-576

Each HeaderSlice has a status:

	// intialized, needs to be obtained
    Empty,
	// fetch request sent to sentry
    Waiting,
	// received from sentry
    Downloaded,
    // block hashes are matching the expected ones
    Verified,
    // saved in the database
    Saved,


Downloading happens with several stages where each of the stages processes blocks in one status, and updates them to proceed to the next status. All stages runs in parallel, although most of the time only one of the stages is actively running, while the others are waiting for the status updates or timeouts.

Stages:

1. FetchRequestStage - sends requests to P2P via sentry to get the slices. Slices become Waiting.
2. FetchReceiveStage - receives the slices, and sets Downloaded status.
3. RetryStage - handles timeouts. If a slice is Waiting for too long, we need to request it again. Status is updated to Empty (the slice will be processed by the FetchRequestStage again).
4. VerifyStage - checks that block hashes are matching the expected ones and sets Verified status.
5. SaveStage - saves slices into the database, and sets Saved status.
6. RefillStage - forgets the Saved slices from memory, and creates more Empty slices until we reach the end of preverified chain.


Things to do:

* implement verify, save stages
* improve RetryStage algorithm to only refetch slices that are Waiting for too long

## HeaderSlices UI

If compiled with `--features crossterm`, the terminal-based UI shows
the download progress and statuses of each header slice.
This feature is optional.

Example:

    cargo run --bin akula-ddl --features crossterm -- --chain ropsten 

![Screenshot 2021-08-22 at 16 20 14](https://user-images.githubusercontent.com/11477595/130358510-a61cfccf-1f58-46b9-901a-58575495e053.png)
