### PR TITLE
RetryStage: retry requests only if needed.

### DIFF
--- a/src/downloader/headers/fetch_request_stage.rs
+++ b/src/downloader/headers/fetch_request_stage.rs
@@ -13,6 +13,7 @@ use std::{
     cell::{Cell, RefCell},
     ops::DerefMut,
     sync::Arc,
+    time,
 };
 use tokio::sync::watch;
 use tracing::*;
@@ -82,6 +83,7 @@ impl FetchRequestStage {
                     },
                     Ok(_) => {
                         let mut slice = RwLockUpgradableReadGuard::upgrade(slice);
+                        slice.request_time = Some(time::Instant::now());
                         self.header_slices
                             .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Waiting);
                     }

--- a/src/downloader/headers/retry_stage.rs
+++ b/src/downloader/headers/retry_stage.rs
@@ -1,6 +1,6 @@
-use crate::downloader::headers::header_slices::{HeaderSliceStatus, HeaderSlices};
+use crate::downloader::headers::header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices};
 use parking_lot::lock_api::RwLockUpgradableReadGuard;
-use std::{cell::RefCell, ops::DerefMut, sync::Arc};
+use std::{cell::RefCell, ops::DerefMut, sync::Arc, time, time::Duration};
 use tokio::sync::watch;
 use tracing::*;
 
@@ -37,26 +37,53 @@ impl RetryStage {
             debug!("RetryStage: waiting pending done");
         }
 
-        // retry if nothing happens for 10 sec
-        // TODO: ideally need to respect the time when Waiting was started,
-        //     and only reset those that wait for too long
-        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        // don't retry more often than once per 1 sec
+        tokio::time::sleep(Duration::from_secs(1)).await;
 
-        info!("RetryStage: resetting {} slices", self.pending_count());
-        self.reset_pending()?;
+        let count = self.reset_pending()?;
+        if count > 0 {
+            info!("RetryStage: did reset {} slices for retry", count);
+        }
         debug!("RetryStage: done");
         Ok(())
     }
 
-    fn reset_pending(&self) -> anyhow::Result<()> {
+    fn reset_pending(&self) -> anyhow::Result<usize> {
+        let now = time::Instant::now();
+        let mut count: usize = 0;
         self.header_slices.for_each(|slice_lock| {
             let slice = slice_lock.upgradable_read();
-            if slice.status == HeaderSliceStatus::Waiting {
+            if (slice.status == HeaderSliceStatus::Waiting)
+                && RetryStage::is_waiting_timeout_expired(&slice, &now)
+            {
                 let mut slice = RwLockUpgradableReadGuard::upgrade(slice);
+                slice.request_time = None;
+                slice.request_attempt += 1;
                 self.header_slices
                     .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Empty);
+                count += 1;
             }
             None
-        })
+        })?;
+        Ok(count)
+    }
+
+    fn is_waiting_timeout_expired(slice: &HeaderSlice, now: &time::Instant) -> bool {
+        if slice.request_time.is_none() {
+            return false;
+        }
+        let request_time = slice.request_time.unwrap();
+        let elapsed = now.duration_since(request_time);
+        let timeout = RetryStage::timeout_for_attempt(slice.request_attempt);
+        elapsed > timeout
+    }
+
+    fn timeout_for_attempt(attempt: u16) -> Duration {
+        match attempt {
+            0 => Duration::from_secs(5),
+            1 => Duration::from_secs(10),
+            2 => Duration::from_secs(15),
+            _ => Duration::from_secs(30),
+        }
     }
 }


### PR DESCRIPTION
If a headers slice fetch request was sent, it gets Waiting status.
When it is Waiting for too long, it can timeout.

Apply the retry logic for each slice individually if it times out.
The timeout has a back off logic: it increases if there's no reply with each retry attempt.