### PR TITLE
RefillStage: stop refilling when everything is loaded

### DIFF
--- a/src/downloader/headers/ui_crossterm.rs
+++ b/src/downloader/headers/ui_crossterm.rs
@@ -24,6 +24,7 @@ impl UIView for HeaderSlicesView {
         let counters = self.header_slices.status_counters();
         let min_block_num = self.header_slices.min_block_num();
         let max_block_num = self.header_slices.max_block_num();
+        let final_block_num = self.header_slices.final_block_num();
 
         let mut stdout = stdout();
 
@@ -36,9 +37,10 @@ impl UIView for HeaderSlicesView {
 
         // overall progress
         let progress_desc = std::format!(
-            "downloading headers {} - {} ...",
-            min_block_num,
-            max_block_num
+            "downloading headers {} - {} of {} ...",
+            min_block_num.0,
+            max_block_num.0,
+            final_block_num.0,
         );
         stdout.queue(style::Print(progress_desc))?;
         stdout.queue(terminal::Clear(terminal::ClearType::UntilNewLine))?;

--- a/src/downloader/headers/verify_stage.rs
+++ b/src/downloader/headers/verify_stage.rs
@@ -98,7 +98,7 @@ impl VerifyStage {
         let last = headers.last().unwrap();
         let last_hash = last.hash();
         let expected_last_hash =
-            self.preverified_hash(slice.start_block_num + headers.len() as u64 - 1);
+            self.preverified_hash(slice.start_block_num.0 + headers.len() as u64 - 1);
         if expected_last_hash.is_none() {
             return false;
         }


### PR DESCRIPTION
Preverified headers downloader process stops when it loads
all header slices until the max known preverified hash.

Since preverified hashes act as slices boundaries,
the number of slices to download is 1 less than the number of hashes.