### PR TITLE
Header downloader: SaveStage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 Cargo.lock
 .idea
+/data
+

--- a/bin/akula-ddl.rs
+++ b/bin/akula-ddl.rs
@@ -1,7 +1,7 @@
 use akula::downloader::{chain_config, opts::Opts, Downloader};
 
 use akula::kv;
-use std::rc::Rc;
+use std::sync::Arc;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -12,7 +12,7 @@ async fn main() -> anyhow::Result<()> {
 
     let chains_config = chain_config::ChainsConfig::new()?;
     let opts = Opts::new(None, chains_config.chain_names().as_slice())?;
-    let db = Rc::new(kv::new_database(&opts.data_dir)?);
+    let db = Arc::new(kv::new_database(&opts.data_dir)?);
     let downloader = Downloader::new(opts, chains_config, db);
     downloader.run(None).await
 }

--- a/bin/akula-ddl.rs
+++ b/bin/akula-ddl.rs
@@ -1,5 +1,7 @@
 use akula::downloader::{chain_config, opts::Opts, Downloader};
 
+use akula::kv;
+use std::rc::Rc;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -10,6 +12,7 @@ async fn main() -> anyhow::Result<()> {
 
     let chains_config = chain_config::ChainsConfig::new()?;
     let opts = Opts::new(None, chains_config.chain_names().as_slice())?;
-    let downloader = Downloader::new(opts, chains_config);
+    let db = Rc::new(kv::new_database(&opts.data_dir)?);
+    let downloader = Downloader::new(opts, chains_config, db);
     downloader.run(None).await
 }

--- a/src/downloader/downloader_impl.rs
+++ b/src/downloader/downloader_impl.rs
@@ -27,11 +27,11 @@ type StageStream = Pin<Box<dyn Stream<Item = anyhow::Result<()>>>>;
 pub struct Downloader<DB: kv::traits::MutableKV> {
     opts: Opts,
     chain_config: ChainConfig,
-    db: Rc<DB>,
+    db: Arc<DB>,
 }
 
 impl<DB: kv::traits::MutableKV> Downloader<DB> {
-    pub fn new(opts: Opts, chains_config: ChainsConfig, db: Rc<DB>) -> Self {
+    pub fn new(opts: Opts, chains_config: ChainsConfig, db: Arc<DB>) -> Self {
         let chain_config = chains_config.0[&opts.chain_name].clone();
 
         Self {
@@ -101,7 +101,7 @@ impl<DB: kv::traits::MutableKV> Downloader<DB> {
 
         let verify_stage = VerifyStage::new(Arc::clone(&header_slices), preverified_hashes_config);
 
-        let save_stage = SaveStage::new(Arc::clone(&header_slices), Rc::clone(&self.db));
+        let save_stage = SaveStage::new(Arc::clone(&header_slices), Arc::clone(&self.db));
 
         let refill_stage = RefillStage::new(Arc::clone(&header_slices));
 

--- a/src/downloader/downloader_impl.rs
+++ b/src/downloader/downloader_impl.rs
@@ -13,6 +13,7 @@ use crate::{
         sentry_client_impl::SentryClientImpl,
         sentry_client_reactor::SentryClientReactor,
     },
+    kv,
     models::BlockNumber,
 };
 use futures_core::Stream;
@@ -23,16 +24,21 @@ use tracing::*;
 
 type StageStream = Pin<Box<dyn Stream<Item = anyhow::Result<()>>>>;
 
-pub struct Downloader {
+pub struct Downloader<DB: kv::traits::MutableKV> {
     opts: Opts,
     chain_config: ChainConfig,
+    db: Rc<DB>,
 }
 
-impl Downloader {
-    pub fn new(opts: Opts, chains_config: ChainsConfig) -> Self {
+impl<DB: kv::traits::MutableKV> Downloader<DB> {
+    pub fn new(opts: Opts, chains_config: ChainsConfig, db: Rc<DB>) -> Self {
         let chain_config = chains_config.0[&opts.chain_name].clone();
 
-        Self { opts, chain_config }
+        Self {
+            opts,
+            chain_config,
+            db,
+        }
     }
 
     pub async fn run(
@@ -95,7 +101,7 @@ impl Downloader {
 
         let verify_stage = VerifyStage::new(Arc::clone(&header_slices), preverified_hashes_config);
 
-        let save_stage = SaveStage::new(Arc::clone(&header_slices));
+        let save_stage = SaveStage::new(Arc::clone(&header_slices), Rc::clone(&self.db));
 
         let refill_stage = RefillStage::new(Arc::clone(&header_slices));
 

--- a/src/downloader/downloader_tests.rs
+++ b/src/downloader/downloader_tests.rs
@@ -2,13 +2,13 @@ use crate::{
     downloader::{chain_config, opts::Opts, sentry_client_mock::SentryClientMock, Downloader},
     kv, new_mem_database,
 };
-use std::rc::Rc;
+use std::sync::Arc;
 
 fn make_downloader() -> Downloader<impl kv::traits::MutableKV> {
     let chains_config = chain_config::ChainsConfig::new().unwrap();
     let args = Vec::<String>::new();
     let opts = Opts::new(Some(args), chains_config.chain_names().as_slice()).unwrap();
-    let db = Rc::new(new_mem_database().unwrap());
+    let db = Arc::new(new_mem_database().unwrap());
     let downloader = Downloader::new(opts, chains_config, db);
     let _ = downloader;
     downloader

--- a/src/downloader/downloader_tests.rs
+++ b/src/downloader/downloader_tests.rs
@@ -1,12 +1,15 @@
-use crate::downloader::{
-    chain_config, opts::Opts, sentry_client_mock::SentryClientMock, Downloader,
+use crate::{
+    downloader::{chain_config, opts::Opts, sentry_client_mock::SentryClientMock, Downloader},
+    kv, new_mem_database,
 };
+use std::rc::Rc;
 
-fn make_downloader() -> Downloader {
+fn make_downloader() -> Downloader<impl kv::traits::MutableKV> {
     let chains_config = chain_config::ChainsConfig::new().unwrap();
     let args = Vec::<String>::new();
     let opts = Opts::new(Some(args), chains_config.chain_names().as_slice()).unwrap();
-    let downloader = Downloader::new(opts, chains_config);
+    let db = Rc::new(new_mem_database().unwrap());
+    let downloader = Downloader::new(opts, chains_config, db);
     let _ = downloader;
     downloader
 }

--- a/src/downloader/headers/fetch_receive_stage.rs
+++ b/src/downloader/headers/fetch_receive_stage.rs
@@ -77,17 +77,13 @@ impl FetchReceiveStage {
         }
         let start_block_num = headers[0].number;
 
-        self.header_slices.find(
-            start_block_num,
-            move |slice_lock_opt: Option<&RwLock<HeaderSlice>>| {
-                self.update_slice(slice_lock_opt, headers, start_block_num);
-            },
-        );
+        let slice_lock_opt = self.header_slices.find_by_start_block_num(start_block_num);
+        self.update_slice(slice_lock_opt, headers, start_block_num);
     }
 
     fn update_slice(
         &self,
-        slice_lock_opt: Option<&RwLock<HeaderSlice>>,
+        slice_lock_opt: Option<Arc<RwLock<HeaderSlice>>>,
         headers: Vec<Header>,
         start_block_num: BlockNumber,
     ) {

--- a/src/downloader/headers/save_stage.rs
+++ b/src/downloader/headers/save_stage.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use parking_lot::lock_api::RwLockUpgradableReadGuard;
 use sha3::Digest;
-use std::{cell::RefCell, ops::DerefMut, rc::Rc, sync::Arc};
+use std::{cell::RefCell, ops::DerefMut, sync::Arc};
 use tokio::sync::watch;
 use tracing::*;
 
@@ -13,11 +13,11 @@ use tracing::*;
 pub struct SaveStage<DB: kv::traits::MutableKV> {
     header_slices: Arc<HeaderSlices>,
     pending_watch: RefCell<watch::Receiver<usize>>,
-    db: Rc<DB>,
+    db: Arc<DB>,
 }
 
 impl<DB: kv::traits::MutableKV> SaveStage<DB> {
-    pub fn new(header_slices: Arc<HeaderSlices>, db: Rc<DB>) -> Self {
+    pub fn new(header_slices: Arc<HeaderSlices>, db: Arc<DB>) -> Self {
         let pending_watch = header_slices.watch_status_changes(HeaderSliceStatus::Verified);
 
         Self {

--- a/src/downloader/headers/save_stage.rs
+++ b/src/downloader/headers/save_stage.rs
@@ -1,22 +1,29 @@
-use crate::downloader::headers::header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices};
+use crate::{
+    downloader::headers::header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices},
+    kv,
+    kv::traits::MutableTransaction,
+};
 use parking_lot::lock_api::RwLockUpgradableReadGuard;
-use std::{cell::RefCell, ops::DerefMut, sync::Arc};
+use sha3::Digest;
+use std::{cell::RefCell, ops::DerefMut, rc::Rc, sync::Arc};
 use tokio::sync::watch;
 use tracing::*;
 
 /// Saves slices into the database, and sets Saved status.
-pub struct SaveStage {
+pub struct SaveStage<DB: kv::traits::MutableKV> {
     header_slices: Arc<HeaderSlices>,
     pending_watch: RefCell<watch::Receiver<usize>>,
+    db: Rc<DB>,
 }
 
-impl SaveStage {
-    pub fn new(header_slices: Arc<HeaderSlices>) -> Self {
+impl<DB: kv::traits::MutableKV> SaveStage<DB> {
+    pub fn new(header_slices: Arc<HeaderSlices>, db: Rc<DB>) -> Self {
         let pending_watch = header_slices.watch_status_changes(HeaderSliceStatus::Verified);
 
         Self {
             header_slices,
             pending_watch: RefCell::new(pending_watch),
+            db,
         }
     }
 
@@ -43,24 +50,30 @@ impl SaveStage {
     }
 
     async fn save_pending(&self) -> anyhow::Result<()> {
-        self.header_slices.for_each(|slice_lock| {
+        while let Some(slice_lock) = self
+            .header_slices
+            .find_by_status(HeaderSliceStatus::Verified)
+        {
             let slice = slice_lock.upgradable_read();
-            if slice.status == HeaderSliceStatus::Verified {
-                let save_result = self.save_slice(&slice);
-                if save_result.is_err() {
-                    return Some(save_result);
-                }
+            self.save_slice(&slice).await?;
 
-                let mut slice = RwLockUpgradableReadGuard::upgrade(slice);
-                self.header_slices
-                    .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Saved);
-            }
-            None
-        })
+            let mut slice = RwLockUpgradableReadGuard::upgrade(slice);
+            self.header_slices
+                .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Saved);
+        }
+        Ok(())
     }
 
-    fn save_slice(&self, _slice: &HeaderSlice) -> anyhow::Result<()> {
-        // TODO: save verified headers to the DB
-        Ok(())
+    async fn save_slice(&self, slice: &HeaderSlice) -> anyhow::Result<()> {
+        let tx = self.db.begin_mutable().await?;
+        if let Some(headers) = slice.headers.as_ref() {
+            for header in headers {
+                let table = &kv::tables::Header;
+                let value = rlp::encode(header);
+                let key = sha3::Keccak256::digest(&value);
+                tx.set(table, &key, &value).await?;
+            }
+        }
+        tx.commit().await
     }
 }

--- a/src/downloader/opts.rs
+++ b/src/downloader/opts.rs
@@ -17,6 +17,12 @@ pub struct Opts {
         default_value = "mainnet"
     )]
     pub chain_name: String,
+    #[structopt(
+        long = "datadir",
+        help = "Database directory path",
+        default_value = "data"
+    )]
+    pub data_dir: std::path::PathBuf,
 }
 
 impl Opts {

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -5,7 +5,7 @@ pub mod traits;
 
 use ::mdbx::{Geometry, WriteMap};
 use async_trait::async_trait;
-use byte_unit::n_mb_bytes;
+use byte_unit::{n_gib_bytes, n_mib_bytes};
 use static_bytes::Bytes as StaticBytes;
 use std::fmt::Debug;
 
@@ -38,7 +38,7 @@ pub mod tables {
 
 pub struct MemoryKv {
     inner: mdbx::Environment<WriteMap>,
-    _tmpdir: tempfile::TempDir,
+    _tmpdir: Option<tempfile::TempDir>,
 }
 
 #[async_trait]
@@ -61,18 +61,31 @@ impl traits::MutableKV for MemoryKv {
 
 pub fn new_mem_database() -> anyhow::Result<impl traits::MutableKV> {
     let tmpdir = tempfile::tempdir()?;
+    Ok(MemoryKv {
+        inner: new_environment(tmpdir.path(), n_mib_bytes!(64), 0)?,
+        _tmpdir: Some(tmpdir),
+    })
+}
+
+pub fn new_database(path: &std::path::Path) -> anyhow::Result<impl traits::MutableKV> {
+    Ok(MemoryKv {
+        inner: new_environment(path, n_gib_bytes!(1), n_mib_bytes!(8) as usize)?,
+        _tmpdir: None,
+    })
+}
+
+fn new_environment(
+    path: &std::path::Path,
+    size_upper_limit: u128,
+    growth_step: usize,
+) -> anyhow::Result<mdbx::Environment<WriteMap>> {
     let mut builder = ::mdbx::Environment::<WriteMap>::new();
     builder.set_max_dbs(tables::TABLE_MAP.len());
     builder.set_geometry(Geometry {
-        size: Some(0..n_mb_bytes!(64) as usize),
-        growth_step: None,
+        size: Some(0..size_upper_limit as usize),
+        growth_step: Some(growth_step as isize),
         shrink_threshold: None,
         page_size: None,
     });
-    let inner = mdbx::Environment::open_rw(builder, tmpdir.path(), &tables::TABLE_MAP)?;
-
-    Ok(MemoryKv {
-        inner,
-        _tmpdir: tmpdir,
-    })
+    mdbx::Environment::open_rw(builder, path, &tables::TABLE_MAP)
 }


### PR DESCRIPTION
SaveStage is by saving the verified headers
into the "Header" table in the key-value database.
It uses the header hashes as keys and RLP data as values.

HeaderSlices is refactored so that find_by_status
is not holding the overall lock.
It returns a detached RC reference to a single HeaderSlice.
This allows to hold the HeaderSlice lock while blocking on await in save_pending,
and let other stages proceed at the same time.