### PR TITLE
Header downloader: queue optimizations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea
+/data

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
 .idea
-/data

--- a/src/downloader/downloader_impl.rs
+++ b/src/downloader/downloader_impl.rs
@@ -60,10 +60,10 @@ impl<DB: kv::traits::MutableKV> Downloader<DB> {
         sentry_client.set_status(status).await?;
 
         let mut sentry_reactor = SentryClientReactor::new(sentry_client);
-        sentry_reactor.start();
+        sentry_reactor.start()?;
 
         let mut ui_system = crate::downloader::ui_system::UISystem::new();
-        ui_system.start();
+        ui_system.start()?;
 
         let preverified_hashes_config = PreverifiedHashesConfig::new(&self.opts.chain_name)?;
 

--- a/src/downloader/headers/fetch_receive_stage.rs
+++ b/src/downloader/headers/fetch_receive_stage.rs
@@ -97,13 +97,13 @@ impl FetchReceiveStage {
                             .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Downloaded);
                     }
                     unexpected_status => {
-                        warn!("FetchReceiveStage ignores a headers slice that we didn't request starting at: {}; status = {:?}", start_block_num, unexpected_status);
+                        debug!("FetchReceiveStage ignores a headers slice that we didn't request starting at: {:?}; status = {:?}", start_block_num, unexpected_status);
                     }
                 }
             }
             None => {
-                warn!(
-                    "FetchReceiveStage ignores a headers slice that we didn't request starting at: {}",
+                debug!(
+                    "FetchReceiveStage ignores a headers slice that we didn't request starting at: {:?}",
                     start_block_num
                 );
             }

--- a/src/downloader/sentry_client.rs
+++ b/src/downloader/sentry_client.rs
@@ -21,7 +21,7 @@ pub enum PeerFilter {
     All,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MessageFromPeer {
     pub message: Message,
     pub from_peer_id: Option<ethereum_types::H512>,

--- a/src/downloader/sentry_client_reactor.rs
+++ b/src/downloader/sentry_client_reactor.rs
@@ -277,13 +277,12 @@ impl SentryClientReactorEventLoop {
 
                             let receive_messages_senders = self.receive_messages_senders.read();
                             let sender_opt = receive_messages_senders.get(&id);
-                            if sender_opt.is_none() {
-                                anyhow::bail!(
+                            let sender = sender_opt.ok_or_else(|| {
+                                anyhow::anyhow!(
                                     "SentryClientReactor.EventLoop unexpected message id {:?}",
                                     id
-                                );
-                            }
-                            let sender = sender_opt.unwrap();
+                                )
+                            })?;
 
                             let send_sub_result = sender.send(message_from_peer.message);
                             if send_sub_result.is_err() {


### PR DESCRIPTION
* refactor SentryClientReactorEventLoop to be able to send and receive simultaneously
previously if sentry.send_message was blocked on await, the loop was making no progress
even if the incoming messages were in in_stream.next.
Now send and receive streams are processed in parallel.

* avoid premature SentryClientReactorEventLoop exit causing fetch_request_stage_stream failure: Err(ReactorStopped)

* avoid retrying queued sent messages by having only 1 message in the channel at a time.
if it is > 1 there's a chance that it is not sent to congested upstream within 5 sec,
and after retry we have 2 identical requests in the queue. When they get executed
we are getting a "slice that we didn't request".
