### PR TITLE
Reconnect to sentry.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea
+/data

--- a/src/downloader/mod.rs
+++ b/src/downloader/mod.rs
@@ -7,6 +7,7 @@ pub mod messages;
 pub mod opts;
 pub mod sentry_address;
 pub mod sentry_client;
+mod sentry_client_connector;
 pub mod sentry_client_impl;
 mod sentry_client_mock;
 

--- a/src/downloader/sentry_client.rs
+++ b/src/downloader/sentry_client.rs
@@ -4,7 +4,7 @@ use crate::downloader::{
 };
 use async_trait::async_trait;
 use futures_core::Stream;
-use std::pin::Pin;
+use std::{fmt::Debug, pin::Pin};
 
 pub struct Status {
     pub total_difficulty: ethereum_types::U256,
@@ -13,7 +13,7 @@ pub struct Status {
     pub max_block: u64,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum PeerFilter {
     MinBlock(u64),
     PeerId(ethereum_types::H512),
@@ -27,8 +27,11 @@ pub struct MessageFromPeer {
     pub from_peer_id: Option<ethereum_types::H512>,
 }
 
+pub type MessageFromPeerStream =
+    Pin<Box<dyn Stream<Item = anyhow::Result<MessageFromPeer>> + Send>>;
+
 #[async_trait]
-pub trait SentryClient: Send {
+pub trait SentryClient: Send + Debug {
     async fn set_status(&mut self, status: Status) -> anyhow::Result<()>;
 
     //async fn penalize_peer(&mut self) -> anyhow::Result<()>;
@@ -43,5 +46,5 @@ pub trait SentryClient: Send {
     async fn receive_messages(
         &mut self,
         filter_ids: &[EthMessageId],
-    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = anyhow::Result<MessageFromPeer>> + Send>>>;
+    ) -> anyhow::Result<MessageFromPeerStream>;
 }

--- a/src/downloader/sentry_client_connector.rs
+++ b/src/downloader/sentry_client_connector.rs
@@ -1,0 +1,63 @@
+use crate::downloader::{
+    sentry_address::SentryAddress, sentry_client::SentryClient,
+    sentry_client_impl::SentryClientImpl,
+};
+use futures_core::Stream;
+use std::pin::Pin;
+use tracing::*;
+
+fn is_tonic_transport_error(error: &anyhow::Error) -> bool {
+    if let Some(transport_error) = error.downcast_ref::<tonic::transport::Error>() {
+        let transport_error_str = format!("{}", transport_error);
+        return transport_error_str == "transport error";
+    }
+    if let Some(status) = error.downcast_ref::<tonic::Status>() {
+        return (status.code() == tonic::Code::Unknown) && (status.message() == "transport error");
+    }
+    false
+}
+
+pub async fn connect(sentry_api_addr: SentryAddress) -> anyhow::Result<Box<dyn SentryClient>> {
+    loop {
+        let result = SentryClientImpl::new(sentry_api_addr.clone()).await;
+        match result {
+            Ok(client) => return Ok(Box::new(client)),
+            Err(error) => {
+                if is_tonic_transport_error(&error) {
+                    error!("Sentry server is unreachable at {:?}", sentry_api_addr);
+                    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+                    continue;
+                }
+                return Err(error);
+            }
+        }
+    }
+}
+
+pub type SentryClientConnectorStream =
+    Pin<Box<dyn Stream<Item = anyhow::Result<Box<dyn SentryClient>>> + Send>>;
+
+pub fn make_connector_stream(
+    sentry_client: Box<dyn SentryClient>,
+    sentry_api_addr: SentryAddress,
+) -> SentryClientConnectorStream {
+    Box::pin(async_stream::stream! {
+        yield Ok(sentry_client);
+        loop {
+            let client = connect(sentry_api_addr.clone()).await?;
+            yield Ok(client);
+        }
+    })
+}
+
+pub fn is_disconnect_error(error: &anyhow::Error) -> bool {
+    if let Some(io_error) = error.downcast_ref::<std::io::Error>() {
+        if io_error.kind() == std::io::ErrorKind::BrokenPipe {
+            return true;
+        }
+    }
+    if is_tonic_transport_error(error) {
+        return true;
+    }
+    false
+}

--- a/src/downloader/sentry_client_impl.rs
+++ b/src/downloader/sentry_client_impl.rs
@@ -8,6 +8,7 @@ use std::pin::Pin;
 use tokio_stream::StreamExt;
 use tracing::*;
 
+#[derive(Debug)]
 pub struct SentryClientImpl {
     client: grpc_sentry::sentry_client::SentryClient<tonic::transport::channel::Channel>,
 }
@@ -101,7 +102,7 @@ impl SentryClient for SentryClientImpl {
     async fn receive_messages(
         &mut self,
         filter_ids: &[EthMessageId],
-    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = anyhow::Result<MessageFromPeer>> + Send>>> {
+    ) -> anyhow::Result<MessageFromPeerStream> {
         let grpc_ids = filter_ids
             .iter()
             .map(|id| grpc_sentry::MessageId::from(*id) as i32)

--- a/src/downloader/sentry_client_mock.rs
+++ b/src/downloader/sentry_client_mock.rs
@@ -1,12 +1,12 @@
 use crate::downloader::{
     messages::{EthMessageId, Message},
-    sentry_client::{MessageFromPeer, PeerFilter, SentryClient, Status},
+    sentry_client::{MessageFromPeer, MessageFromPeerStream, PeerFilter, SentryClient, Status},
 };
-use futures_core::Stream;
-use std::{collections::HashSet, pin::Pin};
+use std::collections::HashSet;
 use tokio::sync::broadcast;
 use tokio_stream::{wrappers, StreamExt};
 
+#[derive(Debug)]
 pub struct SentryClientMock {
     message_sender: Option<broadcast::Sender<MessageFromPeer>>,
     message_receiver: Option<broadcast::Receiver<MessageFromPeer>>,
@@ -44,7 +44,7 @@ impl SentryClient for SentryClientMock {
     async fn receive_messages(
         &mut self,
         filter_ids: &[EthMessageId],
-    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = anyhow::Result<MessageFromPeer>> + Send>>> {
+    ) -> anyhow::Result<MessageFromPeerStream> {
         let filter_ids_set = filter_ids
             .iter()
             .cloned()


### PR DESCRIPTION
**sentry_client_connector** module implements the basic reconnection logic: connecting to sentry GRPC and retrying every 5 sec on failure. This logic is reused for the initial connection (before status is sent), and also for disconnects happening during downloading.

**connector_stream** is a stream that produces the initial connected sentry client, and then new clients after each reconnect. polling this stream for the first time returns the connected client. polling it for the second, third etc. time forces a new connection (after some retries) and a new client.

When a disconnect is detected (during send or receive), we have to reconnect and recreate the send/receive streams providing a new sentry client. During that time the send/receive handling is paused (by removing the streams from the stream map), and then restarted (by adding new streams).

When reactor is stopped externally, we need to stop reconnecting. In order to achieve this the sentry connector stream is attached to the same reactor loop that reacts to stop signals.

Note: mpsc channel is good for controlling back pressure, because it blocks or returns a failure when it is full, but it only supports one subscriber (send_message_receiver). We need to have an exclusive mutable reference in order to get messages from it. But for reconnecting we actually need to stop receiving and restart it with a different streams setup. In order to share this subscriber across reconnects a tokio::sync::Mutex is used. The initial send_stream holds this mutex exclusively. When a disconnect happens, the send stream is discarded and the mutex is unlocked. When we reconnect, the new send stream is attached and it retakes the mutex.

