### PR TITLE
Downloader: refactor status watches in stages.

### DIFF
--- a/src/downloader/headers/header_slice_status_watch.rs
+++ b/src/downloader/headers/header_slice_status_watch.rs
@@ -1,0 +1,37 @@
+use crate::downloader::headers::header_slices::{HeaderSliceStatus, HeaderSlices};
+use std::sync::Arc;
+use tokio::sync::watch;
+use tracing::*;
+
+pub struct HeaderSliceStatusWatch {
+    status: HeaderSliceStatus,
+    header_slices: Arc<HeaderSlices>,
+    pending_watch: watch::Receiver<usize>,
+    name: String,
+}
+
+impl HeaderSliceStatusWatch {
+    pub fn new(status: HeaderSliceStatus, header_slices: Arc<HeaderSlices>, name: &str) -> Self {
+        Self {
+            status,
+            header_slices: header_slices.clone(),
+            pending_watch: header_slices.watch_status_changes(status),
+            name: String::from(name),
+        }
+    }
+
+    pub fn pending_count(&self) -> usize {
+        self.header_slices.count_slices_in_status(self.status)
+    }
+
+    pub async fn wait(&mut self) -> anyhow::Result<()> {
+        if self.pending_count() == 0 {
+            debug!("{}: waiting pending", self.name);
+            while *self.pending_watch.borrow_and_update() == 0 {
+                self.pending_watch.changed().await?;
+            }
+            debug!("{}: waiting pending done", self.name);
+        }
+        Ok(())
+    }
+}

--- a/src/downloader/headers/mod.rs
+++ b/src/downloader/headers/mod.rs
@@ -1,3 +1,4 @@
+mod header_slice_status_watch;
 pub mod header_slices;
 
 pub mod fetch_receive_stage;


### PR DESCRIPTION
The "wait for slices in status X" logic was duplicated across stages.
This PR refactors it into a HeaderSliceStatusWatch helper.