### PR TITLE
Rollback parking_lot send_guard feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ modular-bitfield = "0.11"
 num-bigint = "0.4"
 num-traits = "0.2"
 once_cell = "1"
-parking_lot = { version = "0.11", features = ["send_guard"] }
+parking_lot = "0.11"
 pin-utils = "0.1"
 rand = "0.8"
 rayon = "1"


### PR DESCRIPTION
The header downloader SaveStage is adapted to not rely on this feature.

This feature allows locking the RwLock across threads,
but in async runtime it can cause deadlocks,
because hard-locking a thread disables it for the async scheduling.