### PR TITLE
Downloader: monotonic saving.

### DIFF
--- a/src/downloader/headers/header_slice_status_watch.rs
+++ b/src/downloader/headers/header_slice_status_watch.rs
@@ -25,9 +25,13 @@ impl HeaderSliceStatusWatch {
     }
 
     pub async fn wait(&mut self) -> anyhow::Result<()> {
-        if self.pending_count() == 0 {
+        self.wait_while(0).await
+    }
+
+    pub async fn wait_while(&mut self, value: usize) -> anyhow::Result<()> {
+        if self.pending_count() == value {
             debug!("{}: waiting pending", self.name);
-            while *self.pending_watch.borrow_and_update() == 0 {
+            while *self.pending_watch.borrow_and_update() == value {
                 self.pending_watch.changed().await?;
             }
             debug!("{}: waiting pending done", self.name);

--- a/src/downloader/headers/header_slices.rs
+++ b/src/downloader/headers/header_slices.rs
@@ -166,6 +166,16 @@ impl HeaderSlices {
             .map(Arc::clone)
     }
 
+    pub fn find_first(&self) -> Option<Arc<RwLock<HeaderSlice>>> {
+        let slices = self.slices.read();
+        slices.front().map(Arc::clone)
+    }
+
+    pub fn find_by_index(&self, index: usize) -> Option<Arc<RwLock<HeaderSlice>>> {
+        let slices = self.slices.read();
+        slices.iter().nth(index).map(Arc::clone)
+    }
+
     pub fn remove(&self, status: HeaderSliceStatus) {
         let mut slices = self.slices.write();
         let mut cursor = slices.cursor_front_mut();

--- a/src/downloader/headers/save_stage.rs
+++ b/src/downloader/headers/save_stage.rs
@@ -1,13 +1,14 @@
 use crate::{
     downloader::headers::{
         header_slice_status_watch::HeaderSliceStatusWatch,
-        header_slices::{HeaderSliceStatus, HeaderSlices},
+        header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices},
     },
     kv,
     kv::traits::MutableTransaction,
     models::BlockHeader,
 };
 use anyhow::anyhow;
+use parking_lot::RwLock;
 use std::{ops::DerefMut, sync::Arc};
 use tracing::*;
 
@@ -15,6 +16,7 @@ use tracing::*;
 pub struct SaveStage<DB: kv::traits::MutableKV + Sync> {
     header_slices: Arc<HeaderSlices>,
     pending_watch: HeaderSliceStatusWatch,
+    remaining_count: usize,
     db: Arc<DB>,
 }
 
@@ -27,53 +29,87 @@ impl<DB: kv::traits::MutableKV + Sync> SaveStage<DB> {
                 header_slices,
                 "SaveStage",
             ),
+            remaining_count: 0,
             db,
         }
     }
 
     pub async fn execute(&mut self) -> anyhow::Result<()> {
         debug!("SaveStage: start");
-        self.pending_watch.wait().await?;
 
-        debug!(
-            "SaveStage: saving {} slices",
-            self.pending_watch.pending_count()
-        );
-        self.save_pending().await?;
+        // initially remaining_count = 0, so we wait for any verified slices to try to save them
+        // since we want to save headers sequentially, there might be some remaining headers
+        // in this case we wait until some more slices become verified
+        // hopefully its the slices at the front so that we can save them
+        self.pending_watch.wait_while(self.remaining_count).await?;
+
+        let pending_count = self.pending_watch.pending_count();
+
+        debug!("SaveStage: saving {} slices", pending_count);
+        let saved_count = self.save_pending_monotonic(pending_count).await?;
+        debug!("SaveStage: saved {} slices", saved_count);
+
+        self.remaining_count = pending_count - saved_count;
+
         debug!("SaveStage: done");
         Ok(())
     }
 
-    async fn save_pending(&self) -> anyhow::Result<()> {
+    async fn save_pending_monotonic(&mut self, pending_count: usize) -> anyhow::Result<usize> {
+        let mut saved_count: usize = 0;
+        for i in 0..pending_count {
+            let slice_lock = self.header_slices.find_by_index(i).ok_or_else(|| {
+                anyhow!("SaveStage: inconsistent state - less pending slices than expected")
+            })?;
+            let is_verified = slice_lock.read().status == HeaderSliceStatus::Verified;
+            if is_verified {
+                self.save_slice(slice_lock).await?;
+                saved_count += 1;
+            } else {
+                break;
+            }
+        }
+        Ok(saved_count)
+    }
+
+    // this is kept for performance comparison with save_pending_monotonic
+    async fn save_pending_all(&self, _pending_count: usize) -> anyhow::Result<usize> {
+        let mut saved_count: usize = 0;
         while let Some(slice_lock) = self
             .header_slices
             .find_by_status(HeaderSliceStatus::Verified)
         {
-            // take out the headers, and unlock the slice while save_slice is in progress
-            let headers = {
-                let mut slice = slice_lock.write();
-                slice.headers.take().ok_or_else(|| {
-                    anyhow!("SaveStage: inconsistent state - Verified slice has no headers")
-                })?
-            };
-
-            self.save_slice(&headers).await?;
-
-            let mut slice = slice_lock.write();
-
-            // put the detached headers back
-            slice.headers = Some(headers);
-
-            self.header_slices
-                .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Saved);
+            self.save_slice(slice_lock).await?;
+            saved_count += 1;
         }
+        Ok(saved_count)
+    }
+
+    async fn save_slice(&self, slice_lock: Arc<RwLock<HeaderSlice>>) -> anyhow::Result<()> {
+        // take out the headers, and unlock the slice while save_slice is in progress
+        let headers = {
+            let mut slice = slice_lock.write();
+            slice.headers.take().ok_or_else(|| {
+                anyhow!("SaveStage: inconsistent state - Verified slice has no headers")
+            })?
+        };
+
+        self.save_headers(&headers).await?;
+
+        let mut slice = slice_lock.write();
+
+        // put the detached headers back
+        slice.headers = Some(headers);
+
+        self.header_slices
+            .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Saved);
         Ok(())
     }
 
-    async fn save_slice(&self, headers: &[BlockHeader]) -> anyhow::Result<()> {
+    async fn save_headers(&self, headers: &[BlockHeader]) -> anyhow::Result<()> {
         let tx = self.db.begin_mutable().await?;
         for header_ref in headers {
-            // TODO: heavy clone - is it possible to avoid?
+            // this clone happens mostly on the stack (except extra_data)
             let header = header_ref.clone();
             tx.set(
                 &kv::tables::Header,


### PR DESCRIPTION
Saving headers in the increasing block number order
might give performance benefits.