### PR TITLE
Downloader: verify_slice_difficulties.

### DIFF
--- a/src/downloader/downloader_impl.rs
+++ b/src/downloader/downloader_impl.rs
@@ -62,7 +62,7 @@ impl<DB: kv::traits::MutableKV + Sync> Downloader<DB> {
         let ui_system = Arc::new(Mutex::new(ui_system));
 
         let headers_downloader = super::headers::downloader::Downloader::new(
-            self.opts.chain_name.clone(),
+            self.chain_config.clone(),
             sentry.clone(),
             self.db.clone(),
             ui_system.clone(),

--- a/src/downloader/headers/downloader.rs
+++ b/src/downloader/headers/downloader.rs
@@ -4,13 +4,13 @@ use crate::{
         ui_system::UISystem,
     },
     kv,
-    sentry::sentry_client_reactor::*,
+    sentry::{chain_config::ChainConfig, sentry_client_reactor::*},
 };
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 pub struct Downloader<DB: kv::traits::MutableKV + Sync> {
-    chain_name: String,
+    chain_config: ChainConfig,
     sentry: SentryClientReactorShared,
     db: Arc<DB>,
     ui_system: Arc<Mutex<UISystem>>,
@@ -18,13 +18,13 @@ pub struct Downloader<DB: kv::traits::MutableKV + Sync> {
 
 impl<DB: kv::traits::MutableKV + Sync> Downloader<DB> {
     pub fn new(
-        chain_name: String,
+        chain_config: ChainConfig,
         sentry: SentryClientReactorShared,
         db: Arc<DB>,
         ui_system: Arc<Mutex<UISystem>>,
     ) -> Self {
         Self {
-            chain_name,
+            chain_config,
             sentry,
             db,
             ui_system,
@@ -35,7 +35,7 @@ impl<DB: kv::traits::MutableKV + Sync> Downloader<DB> {
         let mem_limit = 50 << 20; /* 50 Mb */
 
         let downloader_preverified = downloader_preverified::DownloaderPreverified::new(
-            self.chain_name.clone(),
+            self.chain_config.chain_name(),
             mem_limit,
             self.sentry.clone(),
             self.db.clone(),
@@ -46,7 +46,7 @@ impl<DB: kv::traits::MutableKV + Sync> Downloader<DB> {
             downloader_preverified.run().await?;
 
         let _downloader_linear = downloader_linear::DownloaderLinear::new(
-            self.chain_name.clone(),
+            self.chain_config.clone(),
             final_preverified_block_num,
             final_preverified_block_hash,
             mem_limit,

--- a/src/downloader/headers/downloader_linear.rs
+++ b/src/downloader/headers/downloader_linear.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     kv,
     models::BlockNumber,
-    sentry::sentry_client_reactor::*,
+    sentry::{chain_config::ChainConfig, sentry_client_reactor::*},
 };
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -19,7 +19,7 @@ use tokio_stream::{StreamExt, StreamMap};
 use tracing::*;
 
 pub struct DownloaderLinear<DB: kv::traits::MutableKV + Sync> {
-    chain_name: String,
+    chain_config: ChainConfig,
     start_block_num: BlockNumber,
     start_block_hash: ethereum_types::H256,
     mem_limit: usize,
@@ -30,7 +30,7 @@ pub struct DownloaderLinear<DB: kv::traits::MutableKV + Sync> {
 
 impl<DB: kv::traits::MutableKV + Sync> DownloaderLinear<DB> {
     pub fn new(
-        chain_name: String,
+        chain_config: ChainConfig,
         start_block_num: BlockNumber,
         start_block_hash: ethereum_types::H256,
         mem_limit: usize,
@@ -39,7 +39,7 @@ impl<DB: kv::traits::MutableKV + Sync> DownloaderLinear<DB> {
         ui_system: Arc<Mutex<UISystem>>,
     ) -> Self {
         Self {
-            chain_name,
+            chain_config,
             start_block_num,
             start_block_hash,
             mem_limit,
@@ -84,10 +84,14 @@ impl<DB: kv::traits::MutableKV + Sync> DownloaderLinear<DB> {
         );
         let fetch_receive_stage = FetchReceiveStage::new(header_slices.clone(), sentry.clone());
         let retry_stage = RetryStage::new(header_slices.clone());
-        let verify_stage =
-            VerifyStageLinear::new(header_slices.clone(), header_slices::HEADER_SLICE_SIZE);
+        let verify_stage = VerifyStageLinear::new(
+            header_slices.clone(),
+            header_slices::HEADER_SLICE_SIZE,
+            self.chain_config.clone(),
+        );
         let verify_link_stage = VerifyStageLinearLink::new(
             header_slices.clone(),
+            self.chain_config.clone(),
             self.start_block_num,
             self.start_block_hash,
         );

--- a/src/downloader/headers/preverified_hashes_config.rs
+++ b/src/downloader/headers/preverified_hashes_config.rs
@@ -21,8 +21,8 @@ struct PreverifiedHashesConfigUnprefixedHex {
 
 impl PreverifiedHashesConfig {
     pub fn new(chain_name: &str) -> anyhow::Result<Self> {
-        let config_text = match chain_name {
-            "mainnet" => include_str!("preverified_hashes_mainnet.toml"),
+        let config_text = match chain_name.to_lowercase().as_str() {
+            "mainnet" | "ethereum" => include_str!("preverified_hashes_mainnet.toml"),
             "ropsten" => include_str!("preverified_hashes_ropsten.toml"),
             _ => anyhow::bail!("unsupported chain"),
         };

--- a/src/sentry/chain_config.rs
+++ b/src/sentry/chain_config.rs
@@ -29,6 +29,14 @@ impl ChainConfig {
         self.chain_spec.params.chain_id
     }
 
+    pub fn chain_name(&self) -> String {
+        self.chain_spec.name.clone()
+    }
+
+    pub fn chain_spec(&self) -> &ChainSpec {
+        &self.chain_spec
+    }
+
     pub fn genesis_block_hash(&self) -> ethereum_types::H256 {
         self.genesis_block_hash
     }
@@ -43,6 +51,10 @@ impl ChainsConfig {
         let mut configs = HashMap::<String, ChainConfig>::new();
         configs.insert(
             String::from("mainnet"),
+            ChainConfig::new(crate::res::chainspec::MAINNET.clone()),
+        );
+        configs.insert(
+            String::from("ethereum"),
             ChainConfig::new(crate::res::chainspec::MAINNET.clone()),
         );
         configs.insert(


### PR DESCRIPTION
During the linear header download phase we need to verify that the header difficulty field is correct
with respect to its parent header (and the current chain config rules).

VerifyStageLinear stage checks that this relation holds between each sequential pair of a headers slice.
VerifyStageLinearLink stage checks this relation on the slice edges - between the last header of a previous verified slice (last verified header) and the first header of an internally verified slice.
