### PR TITLE
Downloader: verify slice sizes.

### DIFF
--- a/src/downloader/headers/downloader_linear.rs
+++ b/src/downloader/headers/downloader_linear.rs
@@ -85,7 +85,8 @@ impl<DB: kv::traits::MutableKV + Sync> DownloaderLinear<DB> {
         );
         let fetch_receive_stage = FetchReceiveStage::new(header_slices.clone(), sentry.clone());
         let retry_stage = RetryStage::new(header_slices.clone());
-        let verify_stage = VerifyStageLinear::new(header_slices.clone());
+        let verify_stage =
+            VerifyStageLinear::new(header_slices.clone(), header_slices::HEADER_SLICE_SIZE);
         let verify_link_stage = VerifyStageLinearLink::new(
             header_slices.clone(),
             self.start_block_num,

--- a/src/downloader/headers/verify_stage_linear.rs
+++ b/src/downloader/headers/verify_stage_linear.rs
@@ -10,13 +10,15 @@ use tracing::*;
 /// Verifies the block structure and sequence rules in each slice and sets VerifiedInternally status.
 pub struct VerifyStageLinear {
     header_slices: Arc<HeaderSlices>,
+    slice_size: usize,
     pending_watch: HeaderSliceStatusWatch,
 }
 
 impl VerifyStageLinear {
-    pub fn new(header_slices: Arc<HeaderSlices>) -> Self {
+    pub fn new(header_slices: Arc<HeaderSlices>, slice_size: usize) -> Self {
         Self {
             header_slices: header_slices.clone(),
+            slice_size,
             pending_watch: HeaderSliceStatusWatch::new(
                 HeaderSliceStatus::Downloaded,
                 header_slices,
@@ -71,6 +73,9 @@ impl VerifyStageLinear {
             return false;
         }
         let headers = slice.headers.as_ref().unwrap();
+        if headers.len() != self.slice_size {
+            return false;
+        }
 
         header_slice_verifier::verify_slice_is_linked_by_parent_hash(headers)
             && header_slice_verifier::verify_slice_block_nums(headers, slice.start_block_num)

--- a/src/downloader/headers/verify_stage_preverified.rs
+++ b/src/downloader/headers/verify_stage_preverified.rs
@@ -86,7 +86,7 @@ impl VerifyStagePreverified {
         let headers = slice.headers.as_ref().unwrap();
 
         if headers.is_empty() {
-            return true;
+            return false;
         }
 
         let first = headers.first().unwrap();


### PR DESCRIPTION
If the fetched slice is empty or has a size that doesn't match to requested,
we need to fail the verification in order to try to download it again.