### PR TITLE
Downloader: penalize a peer if we fail to verify.

### DIFF
--- a/src/downloader/downloader_impl.rs
+++ b/src/downloader/downloader_impl.rs
@@ -9,9 +9,8 @@ use crate::{
         sentry_client_reactor::SentryClientReactor,
     },
 };
-use parking_lot::RwLock;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 
 pub struct Downloader<DB: kv::traits::MutableKV + Sync> {
     opts: Opts,
@@ -70,7 +69,7 @@ impl<DB: kv::traits::MutableKV + Sync> Downloader<DB> {
         ui_system.try_lock()?.stop().await?;
 
         {
-            let mut sentry_reactor = sentry.write();
+            let mut sentry_reactor = sentry.write().await;
             sentry_reactor.stop().await?;
         }
 

--- a/src/downloader/headers/downloader.rs
+++ b/src/downloader/headers/downloader.rs
@@ -4,15 +4,14 @@ use crate::{
         ui_system::UISystem,
     },
     kv,
-    sentry::sentry_client_reactor::SentryClientReactor,
+    sentry::sentry_client_reactor::*,
 };
-use parking_lot::RwLock;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 pub struct Downloader<DB: kv::traits::MutableKV + Sync> {
     chain_name: String,
-    sentry: Arc<RwLock<SentryClientReactor>>,
+    sentry: SentryClientReactorShared,
     db: Arc<DB>,
     ui_system: Arc<Mutex<UISystem>>,
 }
@@ -20,7 +19,7 @@ pub struct Downloader<DB: kv::traits::MutableKV + Sync> {
 impl<DB: kv::traits::MutableKV + Sync> Downloader<DB> {
     pub fn new(
         chain_name: String,
-        sentry: Arc<RwLock<SentryClientReactor>>,
+        sentry: SentryClientReactorShared,
         db: Arc<DB>,
         ui_system: Arc<Mutex<UISystem>>,
     ) -> Self {

--- a/src/downloader/headers/fetch_receive_stage.rs
+++ b/src/downloader/headers/fetch_receive_stage.rs
@@ -3,14 +3,14 @@ use crate::{
         header_slices,
         header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices},
     },
-    models::{BlockHeader as Header, BlockNumber},
+    models::BlockHeader as Header,
     sentry::{
         messages::{BlockHeadersMessage, EthMessageId, Message},
-        sentry_client_reactor::SentryClientReactor,
+        sentry_client::PeerId,
+        sentry_client_reactor::*,
     },
 };
 use futures_core::Stream;
-use parking_lot::RwLock;
 use std::{
     ops::DerefMut,
     pin::Pin,
@@ -20,12 +20,17 @@ use tokio::sync::Mutex;
 use tokio_stream::StreamExt;
 use tracing::*;
 
-type BlockHeadersMessageStream = Pin<Box<dyn Stream<Item = BlockHeadersMessage> + Send>>;
+struct BlockHeadersMessageFromPeer {
+    message: BlockHeadersMessage,
+    from_peer_id: Option<PeerId>,
+}
+
+type BlockHeadersMessageStream = Pin<Box<dyn Stream<Item = BlockHeadersMessageFromPeer> + Send>>;
 
 /// Receives the slices, and sets Downloaded status.
 pub struct FetchReceiveStage {
     header_slices: Arc<HeaderSlices>,
-    sentry: Arc<RwLock<SentryClientReactor>>,
+    sentry: SentryClientReactorShared,
     is_over: Arc<AtomicBool>,
     message_stream: Mutex<Option<BlockHeadersMessageStream>>,
 }
@@ -46,7 +51,7 @@ impl CanProceed {
 }
 
 impl FetchReceiveStage {
-    pub fn new(header_slices: Arc<HeaderSlices>, sentry: Arc<RwLock<SentryClientReactor>>) -> Self {
+    pub fn new(header_slices: Arc<HeaderSlices>, sentry: SentryClientReactorShared) -> Self {
         Self {
             header_slices,
             sentry,
@@ -59,12 +64,13 @@ impl FetchReceiveStage {
         debug!("FetchReceiveStage: start");
         let mut message_stream = self.message_stream.try_lock()?;
         if message_stream.is_none() {
-            *message_stream = Some(self.receive_headers()?);
+            let sentry = self.sentry.read().await;
+            *message_stream = Some(self.receive_headers(&sentry)?);
         }
 
         let message_result = message_stream.as_mut().unwrap().next().await;
         match message_result {
-            Some(message) => self.on_headers(message.headers),
+            Some(message) => self.on_headers_message(message),
             None => self.is_over.store(true, Ordering::SeqCst),
         }
         debug!("FetchReceiveStage: done");
@@ -78,9 +84,10 @@ impl FetchReceiveStage {
         }
     }
 
-    fn on_headers(&self, headers: Vec<Header>) {
+    fn on_headers_message(&self, message_from_peer: BlockHeadersMessageFromPeer) {
         debug!("FetchReceiveStage: received a headers slice");
 
+        let headers = message_from_peer.message.headers;
         if headers.len() < header_slices::HEADER_SLICE_SIZE {
             warn!(
                 "FetchReceiveStage got a headers slice of a smaller size: {}",
@@ -88,30 +95,19 @@ impl FetchReceiveStage {
             );
             return;
         }
+
         let start_block_num = headers[0].number;
-
         let slice_lock_opt = self.header_slices.find_by_start_block_num(start_block_num);
-        self.update_slice(slice_lock_opt, headers, start_block_num);
-    }
 
-    fn update_slice(
-        &self,
-        slice_lock_opt: Option<Arc<RwLock<HeaderSlice>>>,
-        headers: Vec<Header>,
-        start_block_num: BlockNumber,
-    ) {
         match slice_lock_opt {
             Some(slice_lock) => {
                 let mut slice = slice_lock.write();
-                match slice.status {
-                    HeaderSliceStatus::Waiting => {
-                        slice.headers = Some(headers);
-                        self.header_slices
-                            .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Downloaded);
-                    }
-                    unexpected_status => {
-                        debug!("FetchReceiveStage ignores a headers slice that we didn't request starting at: {:?}; status = {:?}", start_block_num, unexpected_status);
-                    }
+                let slice_status = slice.status;
+                if slice_status == HeaderSliceStatus::Waiting {
+                    let from_peer_id = message_from_peer.from_peer_id;
+                    self.update_slice(slice.deref_mut(), headers, from_peer_id);
+                } else {
+                    debug!("FetchReceiveStage ignores a headers slice that we didn't request starting at: {:?}; status = {:?}", start_block_num, slice_status);
                 }
             }
             None => {
@@ -123,15 +119,30 @@ impl FetchReceiveStage {
         }
     }
 
-    fn receive_headers(&self) -> anyhow::Result<BlockHeadersMessageStream> {
-        let in_stream = self
-            .sentry
-            .read()
-            .receive_messages(EthMessageId::BlockHeaders)?;
+    fn update_slice(
+        &self,
+        slice: &mut HeaderSlice,
+        headers: Vec<Header>,
+        from_peer_id: Option<PeerId>,
+    ) {
+        slice.headers = Some(headers);
+        slice.from_peer_id = from_peer_id;
+        self.header_slices
+            .set_slice_status(slice, HeaderSliceStatus::Downloaded);
+    }
 
-        let out_stream = in_stream.map(|message| match message {
-            Message::BlockHeaders(message) => message,
-            _ => panic!("unexpected type {:?}", message.eth_id()),
+    fn receive_headers(
+        &self,
+        sentry: &SentryClientReactor,
+    ) -> anyhow::Result<BlockHeadersMessageStream> {
+        let in_stream = sentry.receive_messages(EthMessageId::BlockHeaders)?;
+
+        let out_stream = in_stream.map(|message_from_peer| match message_from_peer.message {
+            Message::BlockHeaders(message) => BlockHeadersMessageFromPeer {
+                message,
+                from_peer_id: message_from_peer.from_peer_id,
+            },
+            _ => panic!("unexpected type {:?}", message_from_peer.message.eth_id()),
         });
 
         Ok(Box::pin(out_stream))

--- a/src/downloader/headers/header_slices.rs
+++ b/src/downloader/headers/header_slices.rs
@@ -1,4 +1,7 @@
-use crate::models::{BlockHeader as Header, BlockNumber};
+use crate::{
+    models::{BlockHeader as Header, BlockNumber},
+    sentry::sentry_client::PeerId,
+};
 use parking_lot::RwLock;
 use std::{
     collections::{HashMap, LinkedList},
@@ -23,6 +26,8 @@ pub enum HeaderSliceStatus {
     VerifiedInternally,
     // headers of the slice and linked in a proper way to a known verified header
     Verified,
+    // verification failed
+    Invalid,
     // saved in the database
     Saved,
 }
@@ -31,6 +36,7 @@ pub struct HeaderSlice {
     pub start_block_num: BlockNumber,
     pub status: HeaderSliceStatus,
     pub headers: Option<Vec<Header>>,
+    pub from_peer_id: Option<PeerId>,
     pub request_time: Option<time::Instant>,
     pub request_attempt: u16,
 }
@@ -88,6 +94,7 @@ impl HeaderSlices {
                 start_block_num: BlockNumber(start_block_num.0 + (i * HEADER_SLICE_SIZE) as u64),
                 status: HeaderSliceStatus::Empty,
                 headers: None,
+                from_peer_id: None,
                 request_time: None,
                 request_attempt: 0,
             };
@@ -212,6 +219,7 @@ impl HeaderSlices {
                 start_block_num: max_block_num,
                 status: HeaderSliceStatus::Empty,
                 headers: None,
+                from_peer_id: None,
                 request_time: None,
                 request_attempt: 0,
             };

--- a/src/downloader/headers/mod.rs
+++ b/src/downloader/headers/mod.rs
@@ -10,6 +10,7 @@ mod stage_stream;
 mod fetch_receive_stage;
 mod fetch_request_stage;
 mod header_slice_verifier;
+mod penalize_stage;
 mod preverified_hashes_config;
 mod refill_stage;
 mod retry_stage;

--- a/src/downloader/headers/penalize_stage.rs
+++ b/src/downloader/headers/penalize_stage.rs
@@ -1,0 +1,94 @@
+use super::{
+    header_slice_status_watch::HeaderSliceStatusWatch,
+    header_slices::{HeaderSliceStatus, HeaderSlices},
+};
+use crate::sentry::{sentry_client::PeerId, sentry_client_reactor::*};
+use parking_lot::RwLockUpgradableReadGuard;
+use std::{collections::HashSet, ops::DerefMut, sync::Arc};
+use tracing::*;
+
+/// Penalize peers for sending us headers that failed to verify, and mark the related slices as Empty for retry.
+pub struct PenalizeStage {
+    header_slices: Arc<HeaderSlices>,
+    sentry: SentryClientReactorShared,
+    pending_watch: HeaderSliceStatusWatch,
+}
+
+impl PenalizeStage {
+    pub fn new(header_slices: Arc<HeaderSlices>, sentry: SentryClientReactorShared) -> Self {
+        Self {
+            header_slices: header_slices.clone(),
+            sentry,
+            pending_watch: HeaderSliceStatusWatch::new(
+                HeaderSliceStatus::Invalid,
+                header_slices,
+                "PenalizeStage",
+            ),
+        }
+    }
+
+    pub async fn execute(&mut self) -> anyhow::Result<()> {
+        debug!("PenalizeStage: start");
+        self.pending_watch.wait().await?;
+
+        debug!(
+            "PenalizeStage: processing {} invalid slices",
+            self.pending_watch.pending_count()
+        );
+
+        let bad_peers = self.collect_bad_peers()?;
+        warn!(
+            "PenalizeStage: penalizing {} bad peers: {:?}",
+            bad_peers.len(),
+            bad_peers
+        );
+        self.penalize_peers(bad_peers).await?;
+        self.reset_pending()?;
+
+        debug!("PenalizeStage: done");
+        Ok(())
+    }
+
+    fn collect_bad_peers(&self) -> anyhow::Result<HashSet<PeerId>> {
+        let mut peers = HashSet::<PeerId>::new();
+        self.header_slices.for_each(|slice_lock| {
+            let slice = slice_lock.read();
+            if slice.status == HeaderSliceStatus::Invalid {
+                match slice.from_peer_id {
+                    Some(from_peer_id) => { peers.insert(from_peer_id); }
+                    None => warn!("PenalizeStage: got an invalid headers slice from an unknown peer starting at: {:?}", slice.start_block_num),
+                }
+            }
+            None
+        })?;
+        Ok(peers)
+    }
+
+    fn reset_pending(&self) -> anyhow::Result<()> {
+        self.header_slices.for_each(|slice_lock| {
+            let slice = slice_lock.upgradable_read();
+            if slice.status == HeaderSliceStatus::Invalid {
+                let mut slice = RwLockUpgradableReadGuard::upgrade(slice);
+                self.header_slices
+                    .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Empty);
+                slice.headers = None;
+            }
+            None
+        })
+    }
+
+    async fn penalize_peers(&self, peers: HashSet<PeerId>) -> anyhow::Result<()> {
+        let sentry = self.sentry.read().await;
+        for peer_id in peers {
+            sentry.penalize_peer(peer_id).await?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl super::stage::Stage for PenalizeStage {
+    async fn execute(&mut self) -> anyhow::Result<()> {
+        PenalizeStage::execute(self).await
+    }
+}

--- a/src/downloader/headers/ui_crossterm.rs
+++ b/src/downloader/headers/ui_crossterm.rs
@@ -98,6 +98,7 @@ impl From<HeaderSliceStatus> for char {
             HeaderSliceStatus::Downloaded => '.',
             HeaderSliceStatus::VerifiedInternally => '=',
             HeaderSliceStatus::Verified => '#',
+            HeaderSliceStatus::Invalid => 'x',
             HeaderSliceStatus::Saved => '+',
         }
     }

--- a/src/downloader/headers/verify_stage_linear.rs
+++ b/src/downloader/headers/verify_stage_linear.rs
@@ -52,9 +52,7 @@ impl VerifyStageLinear {
                         .set_slice_status(slice.deref_mut(), HeaderSliceStatus::VerifiedInternally);
                 } else {
                     self.header_slices
-                        .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Empty);
-                    slice.headers = None;
-                    // TODO: penalize peer?
+                        .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Invalid);
                 }
             }
             None

--- a/src/downloader/headers/verify_stage_linear_link.rs
+++ b/src/downloader/headers/verify_stage_linear_link.rs
@@ -100,9 +100,7 @@ impl VerifyStageLinearLink {
             }
         } else {
             self.header_slices
-                .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Empty);
-            slice.headers = None;
-            // TODO: penalize peer?
+                .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Invalid);
         }
 
         Some(is_verified)

--- a/src/downloader/headers/verify_stage_preverified.rs
+++ b/src/downloader/headers/verify_stage_preverified.rs
@@ -56,9 +56,7 @@ impl VerifyStagePreverified {
                         .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Verified);
                 } else {
                     self.header_slices
-                        .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Empty);
-                    slice.headers = None;
-                    // TODO: penalize peer?
+                        .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Invalid);
                 }
             }
             None

--- a/src/sentry/sentry_client.rs
+++ b/src/sentry/sentry_client.rs
@@ -13,10 +13,12 @@ pub struct Status {
     pub max_block: u64,
 }
 
+pub type PeerId = ethereum_types::H512;
+
 #[derive(Clone, Debug)]
 pub enum PeerFilter {
     MinBlock(u64),
-    PeerId(ethereum_types::H512),
+    PeerId(PeerId),
     Random(u64 /* max peers */),
     All,
 }
@@ -24,7 +26,7 @@ pub enum PeerFilter {
 #[derive(Clone, Debug)]
 pub struct MessageFromPeer {
     pub message: Message,
-    pub from_peer_id: Option<ethereum_types::H512>,
+    pub from_peer_id: Option<PeerId>,
 }
 
 pub type MessageFromPeerStream =
@@ -34,8 +36,7 @@ pub type MessageFromPeerStream =
 pub trait SentryClient: Send + Debug {
     async fn set_status(&mut self, status: Status) -> anyhow::Result<()>;
 
-    //async fn penalize_peer(&mut self) -> anyhow::Result<()>;
-    //async fn peer_min_block(&mut self) -> anyhow::Result<()>;
+    async fn penalize_peer(&mut self, peer_id: PeerId) -> anyhow::Result<()>;
 
     async fn send_message(
         &mut self,

--- a/src/sentry/sentry_client_mock.rs
+++ b/src/sentry/sentry_client_mock.rs
@@ -2,6 +2,7 @@ use super::{
     messages::{EthMessageId, Message},
     sentry_client::{MessageFromPeer, MessageFromPeerStream, PeerFilter, SentryClient, Status},
 };
+use crate::sentry::sentry_client::PeerId;
 use std::collections::HashSet;
 use tokio::sync::broadcast;
 use tokio_stream::{wrappers, StreamExt};
@@ -29,6 +30,10 @@ impl SentryClientMock {
 #[async_trait::async_trait]
 impl SentryClient for SentryClientMock {
     async fn set_status(&mut self, _status: Status) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn penalize_peer(&mut self, _peer_id: PeerId) -> anyhow::Result<()> {
         Ok(())
     }
 


### PR DESCRIPTION
If a slice verification has failed, we call penalize_peer() on sentry,
which disconnects the peer that has given us this slice.
If the node is full, it will be hard for that peer to reconnect again.
The slice is setup for a retry, and hopefully will be fetched from another peer.

* refactor to use tokio's RwLock on sentry reactor
  in order to be able to call async reactor methods from stages
  (await while holding the read() lock)