### PR TITLE
Downloader: enable 2nd phase and fix the test.

### DIFF
--- a/src/downloader/headers/downloader.rs
+++ b/src/downloader/headers/downloader.rs
@@ -45,7 +45,7 @@ impl<DB: kv::traits::MutableKV + Sync> Downloader<DB> {
         let (final_preverified_block_num, final_preverified_block_hash) =
             downloader_preverified.run().await?;
 
-        let _downloader_linear = downloader_linear::DownloaderLinear::new(
+        let downloader_linear = downloader_linear::DownloaderLinear::new(
             self.chain_config.clone(),
             final_preverified_block_num,
             final_preverified_block_hash,
@@ -55,7 +55,7 @@ impl<DB: kv::traits::MutableKV + Sync> Downloader<DB> {
             self.ui_system.clone(),
         );
 
-        //downloader_linear.run().await?;
+        downloader_linear.run().await?;
 
         Ok(())
     }


### PR DESCRIPTION
Downloader has 2 sequential phases: preverified and linear.

Enabling them both was breaking the downloader test, because in the preverified downloader phase
sending a request closes the SentryClientMock receiver, this causes a reactor loop stream end
and clear the receive_messages_senders to unblock the FetchReceiveStage (and exit the downloader loop).
But then in the linear phase receive_messages() produced an error
"SentryClientReactor unexpected filter_id".

To fix this this condition is checked in receive_messages() and an empty stream is returned,
so that the next FetchReceiveStage immediately ends, and the linear phase loop exits cleanly too.
