### PR TITLE
Downloader: set_status after reconnecting.

### DIFF
--- a/src/sentry/chain_config.rs
+++ b/src/sentry/chain_config.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 pub struct ChainsConfig(HashMap<String, ChainConfig>);
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ChainConfig {
     chain_spec: ChainSpec,
     genesis_block_hash: ethereum_types::H256,

--- a/src/sentry/sentry_client.rs
+++ b/src/sentry/sentry_client.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use futures_core::Stream;
 use std::{fmt::Debug, pin::Pin};
 
+#[derive(Clone, Debug)]
 pub struct Status {
     pub total_difficulty: ethereum_types::U256,
     pub best_hash: ethereum_types::H256,

--- a/src/sentry/sentry_client_connector.rs
+++ b/src/sentry/sentry_client_connector.rs
@@ -1,9 +1,11 @@
 use super::{
-    sentry_address::SentryAddress, sentry_client::SentryClient,
+    sentry_address::SentryAddress,
+    sentry_client::{SentryClient, Status},
     sentry_client_impl::SentryClientImpl,
 };
 use futures_core::Stream;
 use std::pin::Pin;
+use tokio::time;
 use tracing::*;
 
 fn is_tonic_transport_error(error: &anyhow::Error) -> bool {
@@ -17,15 +19,33 @@ fn is_tonic_transport_error(error: &anyhow::Error) -> bool {
     false
 }
 
-pub async fn connect(sentry_api_addr: SentryAddress) -> anyhow::Result<Box<dyn SentryClient>> {
+const RECONNECT_TIMEOUT: u64 = 5; // seconds
+
+pub async fn connect(
+    sentry_api_addr: SentryAddress,
+    status: Status,
+) -> anyhow::Result<Box<dyn SentryClient>> {
     loop {
         let result = SentryClientImpl::new(sentry_api_addr.clone()).await;
         match result {
-            Ok(client) => return Ok(Box::new(client)),
+            Ok(mut client) => {
+                let status_result = client.set_status(status.clone()).await;
+                match status_result {
+                    Ok(_) => return Ok(Box::new(client)),
+                    Err(error) => {
+                        if is_disconnect_error(&error) {
+                            error!("Sentry client disconnected during set_status");
+                            time::sleep(time::Duration::from_secs(RECONNECT_TIMEOUT)).await;
+                            continue;
+                        }
+                        return Err(error);
+                    }
+                }
+            }
             Err(error) => {
                 if is_tonic_transport_error(&error) {
                     error!("Sentry server is unreachable at {:?}", sentry_api_addr);
-                    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+                    time::sleep(time::Duration::from_secs(RECONNECT_TIMEOUT)).await;
                     continue;
                 }
                 return Err(error);
@@ -40,11 +60,12 @@ pub type SentryClientConnectorStream =
 pub fn make_connector_stream(
     sentry_client: Box<dyn SentryClient>,
     sentry_api_addr: SentryAddress,
+    status: Status,
 ) -> SentryClientConnectorStream {
     Box::pin(async_stream::stream! {
         yield Ok(sentry_client);
         loop {
-            let client = connect(sentry_api_addr.clone()).await?;
+            let client = connect(sentry_api_addr.clone(), status.clone()).await?;
             yield Ok(client);
         }
     })


### PR DESCRIPTION
If a sentry process dies and restarts, it forgets the status info.
When reconnected, we need to call set_status again.