### PR TITLE
Downloader: remove view on phase exit.

### DIFF
--- a/src/downloader/headers/downloader_linear.rs
+++ b/src/downloader/headers/downloader_linear.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::{
     downloader::{
         headers::stage_stream::{make_stage_stream, StageStream},
-        ui_system::UISystem,
+        ui_system::{UISystem, UISystemViewScope},
     },
     kv,
     models::BlockNumber,
@@ -93,9 +93,8 @@ impl DownloaderLinear {
         let sentry = self.sentry.clone();
 
         let header_slices_view = HeaderSlicesView::new(header_slices.clone(), "DownloaderLinear");
-        self.ui_system
-            .try_lock()?
-            .set_view(Some(Box::new(header_slices_view)));
+        let _header_slices_view_scope =
+            UISystemViewScope::new(&self.ui_system, Box::new(header_slices_view));
 
         // Downloading happens with several stages where
         // each of the stages processes blocks in one status,

--- a/src/downloader/headers/downloader_preverified.rs
+++ b/src/downloader/headers/downloader_preverified.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{
     downloader::{
         headers::stage_stream::{make_stage_stream, StageStream},
-        ui_system::UISystem,
+        ui_system::{UISystem, UISystemViewScope},
     },
     kv,
     models::BlockNumber,
@@ -80,9 +80,8 @@ impl DownloaderPreverified {
 
         let header_slices_view =
             HeaderSlicesView::new(header_slices.clone(), "DownloaderPreverified");
-        self.ui_system
-            .try_lock()?
-            .set_view(Some(Box::new(header_slices_view)));
+        let _header_slices_view_scope =
+            UISystemViewScope::new(&self.ui_system, Box::new(header_slices_view));
 
         // Downloading happens with several stages where
         // each of the stages processes blocks in one status,


### PR DESCRIPTION
Otherwise it was possible that previous phase keeps printing progress when the next is already started.