### PR TITLE
Downloader refactoring: lift sentry reactor out of the downloader.

### DIFF
--- a/src/downloader/downloader_impl.rs
+++ b/src/downloader/downloader_impl.rs
@@ -1,63 +1,38 @@
+use super::sentry_status_provider::SentryStatusProvider;
 use crate::{
-    downloader::opts::Opts,
     kv,
     models::BlockNumber,
-    sentry::{
-        chain_config::{ChainConfig, ChainsConfig},
-        sentry_client,
-        sentry_client::SentryClient,
-        sentry_client_connector,
-        sentry_client_reactor::SentryClientReactor,
-    },
+    sentry::{chain_config::ChainConfig, sentry_client_reactor::SentryClientReactorShared},
 };
 use std::sync::Arc;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::Mutex;
 
 #[derive(Debug)]
 pub struct Downloader {
-    opts: Opts,
     chain_config: ChainConfig,
+    sentry: SentryClientReactorShared,
+    sentry_status_provider: SentryStatusProvider,
 }
 
 impl Downloader {
-    pub fn new(opts: Opts, chains_config: ChainsConfig) -> anyhow::Result<Self> {
-        let chain_config = chains_config
-            .get(&opts.chain_name)
-            .ok_or_else(|| anyhow::format_err!("unknown chain '{}'", opts.chain_name))?
-            .clone();
-
-        Ok(Self { opts, chain_config })
+    pub fn new(
+        chain_config: ChainConfig,
+        sentry: SentryClientReactorShared,
+        sentry_status_provider: SentryStatusProvider,
+    ) -> Self {
+        Self {
+            chain_config,
+            sentry,
+            sentry_status_provider,
+        }
     }
 
     pub async fn run<'downloader, 'db: 'downloader, RwTx: kv::traits::MutableTransaction<'db>>(
         &'downloader self,
-        sentry_client_opt: Option<Box<dyn SentryClient>>,
         db_transaction: &'downloader RwTx,
         start_block_num: BlockNumber,
     ) -> anyhow::Result<BlockNumber> {
-        let status = sentry_client::Status {
-            total_difficulty: ethereum_types::U256::zero(),
-            best_hash: ethereum_types::H256::zero(),
-            chain_fork_config: self.chain_config.clone(),
-            max_block: 0,
-        };
-
-        let sentry_api_addr = self.opts.sentry_api_addr.clone();
-        let sentry_client = match sentry_client_opt {
-            Some(mut test_client) => {
-                test_client.set_status(status.clone()).await?;
-                test_client
-            }
-            None => {
-                sentry_client_connector::connect(sentry_api_addr.clone(), status.clone()).await?
-            }
-        };
-
-        let sentry_connector =
-            sentry_client_connector::make_connector_stream(sentry_client, sentry_api_addr, status);
-        let mut sentry_reactor = SentryClientReactor::new(sentry_connector);
-        sentry_reactor.start()?;
-        let sentry = Arc::new(RwLock::new(sentry_reactor));
+        self.sentry_status_provider.update(db_transaction).await?;
 
         let mut ui_system = crate::downloader::ui_system::UISystem::new();
         ui_system.start()?;
@@ -65,7 +40,7 @@ impl Downloader {
 
         let headers_downloader = super::headers::downloader::Downloader::new(
             self.chain_config.clone(),
-            sentry.clone(),
+            self.sentry.clone(),
             ui_system.clone(),
         )?;
         let final_block_num = headers_downloader
@@ -73,11 +48,6 @@ impl Downloader {
             .await?;
 
         ui_system.try_lock()?.stop().await?;
-
-        {
-            let mut sentry_reactor = sentry.write().await;
-            sentry_reactor.stop().await?;
-        }
 
         Ok(final_block_num)
     }

--- a/src/downloader/mod.rs
+++ b/src/downloader/mod.rs
@@ -1,6 +1,7 @@
 mod downloader_impl;
 mod headers;
 pub mod opts;
+pub mod sentry_status_provider;
 
 #[cfg(test)]
 mod downloader_tests;

--- a/src/downloader/sentry_status_provider.rs
+++ b/src/downloader/sentry_status_provider.rs
@@ -1,0 +1,45 @@
+use crate::{
+    kv,
+    sentry::{chain_config::ChainConfig, sentry_client::Status, sentry_client_connector},
+};
+use tokio::sync::watch;
+use tokio_stream::{wrappers::WatchStream, StreamExt};
+
+#[derive(Debug)]
+pub struct SentryStatusProvider {
+    chain_config: ChainConfig,
+    sender: watch::Sender<Status>,
+}
+
+impl SentryStatusProvider {
+    pub fn new(chain_config: ChainConfig) -> Self {
+        let genesis_status = Status {
+            total_difficulty: ethereum_types::U256::zero(),
+            best_hash: ethereum_types::H256::zero(),
+            chain_fork_config: chain_config.clone(),
+            max_block: 0,
+        };
+
+        let (sender, _) = watch::channel(genesis_status);
+
+        Self {
+            chain_config,
+            sender,
+        }
+    }
+
+    pub fn current_status_stream(&self) -> sentry_client_connector::StatusStream {
+        let receiver = self.sender.subscribe();
+        let stream = WatchStream::new(receiver).map(Ok);
+        Box::pin(stream)
+    }
+
+    pub async fn update<'db, RwTx: kv::traits::MutableTransaction<'db>>(
+        &self,
+        _tx: &RwTx,
+    ) -> anyhow::Result<()> {
+        // TODO: read from tx and send a new status
+        // self.sender.send(...);
+        Ok(())
+    }
+}

--- a/src/sentry/chain_config.rs
+++ b/src/sentry/chain_config.rs
@@ -29,7 +29,7 @@ impl ChainConfig {
     }
 
     pub fn chain_name(&self) -> String {
-        self.chain_spec.name.clone()
+        self.chain_spec.name.to_lowercase()
     }
 
     pub fn chain_spec(&self) -> &ChainSpec {
@@ -68,7 +68,7 @@ impl ChainsConfig {
     }
 
     pub fn get(&self, chain_name: &str) -> Option<&ChainConfig> {
-        self.0.get(chain_name)
+        self.0.get(&chain_name.to_lowercase())
     }
 }
 

--- a/src/sentry/sentry_client_connector.rs
+++ b/src/sentry/sentry_client_connector.rs
@@ -3,10 +3,83 @@ use super::{
     sentry_client::{SentryClient, Status},
     sentry_client_impl::SentryClientImpl,
 };
+use async_trait::async_trait;
 use futures_core::Stream;
 use std::pin::Pin;
 use tokio::time;
+use tokio_stream::StreamExt;
 use tracing::*;
+
+#[async_trait]
+pub trait SentryClientConnector: Send {
+    async fn connect(&mut self, status: Status) -> anyhow::Result<Box<dyn SentryClient>>;
+}
+
+pub struct SentryClientConnectorImpl {
+    sentry_api_addr: SentryAddress,
+}
+
+impl SentryClientConnectorImpl {
+    pub fn new(sentry_api_addr: SentryAddress) -> Self {
+        Self { sentry_api_addr }
+    }
+}
+
+const RECONNECT_TIMEOUT: u64 = 5; // seconds
+
+#[async_trait]
+impl SentryClientConnector for SentryClientConnectorImpl {
+    async fn connect(&mut self, status: Status) -> anyhow::Result<Box<dyn SentryClient>> {
+        loop {
+            let sentry_api_addr = self.sentry_api_addr.clone();
+            let result = SentryClientImpl::new(sentry_api_addr).await;
+            match result {
+                Ok(mut client) => {
+                    let status_result = client.set_status(status.clone()).await;
+                    match status_result {
+                        Ok(_) => return Ok(Box::new(client)),
+                        Err(error) => {
+                            if is_disconnect_error(&error) {
+                                error!("Sentry client disconnected during set_status");
+                                time::sleep(time::Duration::from_secs(RECONNECT_TIMEOUT)).await;
+                                continue;
+                            }
+                            return Err(error);
+                        }
+                    }
+                }
+                Err(error) => {
+                    if is_tonic_transport_error(&error) {
+                        let sentry_api_addr = self.sentry_api_addr.clone();
+                        error!("Sentry server is unreachable at {:?}", sentry_api_addr);
+                        time::sleep(time::Duration::from_secs(RECONNECT_TIMEOUT)).await;
+                        continue;
+                    }
+                    return Err(error);
+                }
+            }
+        }
+    }
+}
+
+pub type SentryClientConnectorStream =
+    Pin<Box<dyn Stream<Item = anyhow::Result<Box<dyn SentryClient>>> + Send>>;
+
+pub type StatusStream = Pin<Box<dyn Stream<Item = anyhow::Result<Status>> + Send>>;
+
+pub fn make_connector_stream(
+    mut connector: Box<dyn SentryClientConnector>,
+    mut current_status_stream: StatusStream,
+) -> SentryClientConnectorStream {
+    Box::pin(async_stream::stream! {
+        loop {
+            let status = current_status_stream.next().await
+                .unwrap_or(Err(anyhow::format_err!("SentryClientConnectorStream failed to retrieve the current Status.")))?;
+            let client = connector.connect(status).await?;
+            yield Ok(client);
+        }
+    })
+}
 
 fn is_tonic_transport_error(error: &anyhow::Error) -> bool {
     if let Some(transport_error) = error.downcast_ref::<tonic::transport::Error>() {
@@ -19,58 +92,6 @@ fn is_tonic_transport_error(error: &anyhow::Error) -> bool {
     false
 }
 
-const RECONNECT_TIMEOUT: u64 = 5; // seconds
-
-pub async fn connect(
-    sentry_api_addr: SentryAddress,
-    status: Status,
-) -> anyhow::Result<Box<dyn SentryClient>> {
-    loop {
-        let result = SentryClientImpl::new(sentry_api_addr.clone()).await;
-        match result {
-            Ok(mut client) => {
-                let status_result = client.set_status(status.clone()).await;
-                match status_result {
-                    Ok(_) => return Ok(Box::new(client)),
-                    Err(error) => {
-                        if is_disconnect_error(&error) {
-                            error!("Sentry client disconnected during set_status");
-                            time::sleep(time::Duration::from_secs(RECONNECT_TIMEOUT)).await;
-                            continue;
-                        }
-                        return Err(error);
-                    }
-                }
-            }
-            Err(error) => {
-                if is_tonic_transport_error(&error) {
-                    error!("Sentry server is unreachable at {:?}", sentry_api_addr);
-                    time::sleep(time::Duration::from_secs(RECONNECT_TIMEOUT)).await;
-                    continue;
-                }
-                return Err(error);
-            }
-        }
-    }
-}
-
-pub type SentryClientConnectorStream =
-    Pin<Box<dyn Stream<Item = anyhow::Result<Box<dyn SentryClient>>> + Send>>;
-
-pub fn make_connector_stream(
-    sentry_client: Box<dyn SentryClient>,
-    sentry_api_addr: SentryAddress,
-    status: Status,
-) -> SentryClientConnectorStream {
-    Box::pin(async_stream::stream! {
-        yield Ok(sentry_client);
-        loop {
-            let client = connect(sentry_api_addr.clone(), status.clone()).await?;
-            yield Ok(client);
-        }
-    })
-}
-
 pub fn is_disconnect_error(error: &anyhow::Error) -> bool {
     if let Some(io_error) = error.downcast_ref::<std::io::Error>() {
         if io_error.kind() == std::io::ErrorKind::BrokenPipe {
@@ -81,4 +102,30 @@ pub fn is_disconnect_error(error: &anyhow::Error) -> bool {
         return true;
     }
     false
+}
+
+pub struct SentryClientConnectorTest {
+    test_client: Option<Box<dyn SentryClient>>,
+}
+
+impl SentryClientConnectorTest {
+    pub fn new(test_client: Box<dyn SentryClient>) -> Self {
+        Self {
+            test_client: Some(test_client),
+        }
+    }
+}
+
+#[async_trait]
+impl SentryClientConnector for SentryClientConnectorTest {
+    async fn connect(&mut self, status: Status) -> anyhow::Result<Box<dyn SentryClient>> {
+        if let Some(mut test_client) = self.test_client.take() {
+            test_client.set_status(status).await?;
+            Ok(test_client)
+        } else {
+            Err(anyhow::format_err!(
+                "SentryClientConnectorTest doesn't support reconnects."
+            ))
+        }
+    }
 }


### PR DESCRIPTION
The sentry reactor is managed outside of the staged sync loop,
so that it stays connected all the time,
and it's possible to use the sentry API in any other stages.