### PR TITLE
Downloader: exit stage every N blocks.

### DIFF
--- a/bin/akula-toolbox.rs
+++ b/bin/akula-toolbox.rs
@@ -114,8 +114,12 @@ async fn header_download(
     sentry_reactor.start()?;
     let sentry = Arc::new(RwLock::new(sentry_reactor));
 
-    let stage =
-        akula::stages::HeaderDownload::new(chain_config, sentry.clone(), sentry_status_provider);
+    let stage = akula::stages::HeaderDownload::new(
+        chain_config,
+        opts.headers_batch_size,
+        sentry.clone(),
+        sentry_status_provider,
+    );
     let db = akula::kv::new_database(&data_dir)?;
 
     let mut staged_sync = stagedsync::StagedSync::new();

--- a/src/downloader/headers/header_slices.rs
+++ b/src/downloader/headers/header_slices.rs
@@ -62,7 +62,7 @@ pub struct HeaderSlices {
     state_watches: HashMap<HeaderSliceStatus, HeaderSliceStatusWatch>,
 }
 
-pub const HEADER_SLICE_SIZE: usize = 192;
+pub(super) const HEADER_SLICE_SIZE: usize = 192;
 
 const ATOMIC_ORDERING: Ordering = Ordering::SeqCst;
 
@@ -298,4 +298,9 @@ impl HeaderSlices {
     pub fn is_empty_at_final_position(&self) -> bool {
         (self.max_block_num() >= self.final_block_num) && self.slices.read().is_empty()
     }
+}
+
+pub fn align_block_num_to_slice_start(num: BlockNumber) -> BlockNumber {
+    let slice_size = HEADER_SLICE_SIZE as u64;
+    BlockNumber(num.0 / slice_size * slice_size)
 }

--- a/src/downloader/opts.rs
+++ b/src/downloader/opts.rs
@@ -16,6 +16,12 @@ pub struct Opts {
         default_value = "mainnet"
     )]
     pub chain_name: String,
+    #[structopt(
+        long = "downloader.headers-batch-size",
+        help = "How many headers to download per stage run.",
+        default_value = "100000"
+    )]
+    pub headers_batch_size: usize,
 }
 
 impl Opts {

--- a/src/downloader/ui_system.rs
+++ b/src/downloader/ui_system.rs
@@ -119,7 +119,7 @@ impl UISystemEventLoop {
             }
         }
 
-        info!("UISystem stopped");
+        debug!("UISystemEventLoop stopped");
         Ok(())
     }
 }


### PR DESCRIPTION
To give room to the other stages for processing.

    akula-toolbox download-headers --downloader.headers-batch-size 1920