### PR TITLE
Downloader: mem limit CLI option.

### DIFF
--- a/bin/akula-toolbox.rs
+++ b/bin/akula-toolbox.rs
@@ -116,6 +116,7 @@ async fn header_download(
 
     let stage = akula::stages::HeaderDownload::new(
         chain_config,
+        opts.headers_mem_limit(),
         opts.headers_batch_size,
         sentry.clone(),
         sentry_status_provider,

--- a/src/downloader/downloader_impl.rs
+++ b/src/downloader/downloader_impl.rs
@@ -11,6 +11,7 @@ use tokio::sync::Mutex;
 #[derive(Debug)]
 pub struct Downloader {
     chain_config: ChainConfig,
+    mem_limit: usize,
     sentry: SentryClientReactorShared,
     sentry_status_provider: SentryStatusProvider,
 }
@@ -18,11 +19,13 @@ pub struct Downloader {
 impl Downloader {
     pub fn new(
         chain_config: ChainConfig,
+        mem_limit: usize,
         sentry: SentryClientReactorShared,
         sentry_status_provider: SentryStatusProvider,
     ) -> Self {
         Self {
             chain_config,
+            mem_limit,
             sentry,
             sentry_status_provider,
         }
@@ -42,6 +45,7 @@ impl Downloader {
 
         let headers_downloader = super::headers::downloader::Downloader::new(
             self.chain_config.clone(),
+            self.mem_limit,
             self.sentry.clone(),
             ui_system.clone(),
         )?;

--- a/src/downloader/downloader_tests.rs
+++ b/src/downloader/downloader_tests.rs
@@ -70,6 +70,11 @@ async fn noop() {
     let chain_config = make_chain_config();
     let status_provider = SentryStatusProvider::new(chain_config.clone());
     let sentry_reactor = make_sentry_reactor(sentry, status_provider.current_status_stream());
-    let downloader = Downloader::new(chain_config, sentry_reactor.clone(), status_provider);
+    let downloader = Downloader::new(
+        chain_config,
+        byte_unit::n_mib_bytes!(50) as usize,
+        sentry_reactor.clone(),
+        status_provider,
+    );
     run_downloader(downloader, sentry_reactor).await.unwrap();
 }

--- a/src/downloader/headers/downloader.rs
+++ b/src/downloader/headers/downloader.rs
@@ -27,11 +27,10 @@ pub struct DownloaderReport {
 impl Downloader {
     pub fn new(
         chain_config: ChainConfig,
+        mem_limit: usize,
         sentry: SentryClientReactorShared,
         ui_system: Arc<Mutex<UISystem>>,
     ) -> anyhow::Result<Self> {
-        let mem_limit = 50 << 20; /* 50 Mb */
-
         let downloader_preverified = downloader_preverified::DownloaderPreverified::new(
             chain_config.chain_name(),
             mem_limit,

--- a/src/downloader/opts.rs
+++ b/src/downloader/opts.rs
@@ -17,6 +17,12 @@ pub struct Opts {
     )]
     pub chain_name: String,
     #[structopt(
+        long = "downloader.headers-mem-limit",
+        help = "How much memory in Mb to allocate for the active parallel download window.",
+        default_value = "50"
+    )]
+    pub headers_mem_limit_mb: u32,
+    #[structopt(
         long = "downloader.headers-batch-size",
         help = "How many headers to download per stage run.",
         default_value = "100000"
@@ -42,5 +48,11 @@ impl Opts {
         } else {
             Err(format_err!("unknown chain '{}'", chain_name))
         }
+    }
+
+    pub fn headers_mem_limit(&self) -> usize {
+        byte_unit::n_mib_bytes!(self.headers_mem_limit_mb as u128)
+            .try_into()
+            .unwrap_or(usize::MAX)
     }
 }

--- a/src/stages/downloader.rs
+++ b/src/stages/downloader.rs
@@ -16,11 +16,12 @@ pub struct HeaderDownload {
 impl HeaderDownload {
     pub fn new(
         chain_config: ChainConfig,
+        mem_limit: usize,
         batch_size: usize,
         sentry: SentryClientReactorShared,
         sentry_status_provider: SentryStatusProvider,
     ) -> Self {
-        let downloader = Downloader::new(chain_config, sentry, sentry_status_provider);
+        let downloader = Downloader::new(chain_config, mem_limit, sentry, sentry_status_provider);
 
         Self {
             downloader,


### PR DESCRIPTION
Pass the size of header slices from command line:

    --downloader.headers-mem-limit 50