### PR TITLE
Downloader: fix save_pending_monotonic logic.

### DIFF
--- a/src/downloader/headers/fetch_request_stage.rs
+++ b/src/downloader/headers/fetch_request_stage.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use parking_lot::RwLockUpgradableReadGuard;
 use std::{
-    ops::DerefMut,
+    ops::{ControlFlow, DerefMut},
     sync::{atomic::*, Arc},
     time,
 };
@@ -75,7 +75,7 @@ impl FetchRequestStage {
     }
 
     fn request_pending(&self, sentry: &SentryClientReactor) -> anyhow::Result<()> {
-        self.header_slices.for_each(|slice_lock| {
+        let result = self.header_slices.try_fold((), |_, slice_lock| {
             let slice = slice_lock.upgradable_read();
             if slice.status == HeaderSliceStatus::Empty {
                 let request_id = self.last_request_id.fetch_add(1, Ordering::SeqCst);
@@ -88,10 +88,12 @@ impl FetchRequestStage {
                     Err(error) => match error.downcast_ref::<SendMessageError>() {
                         Some(SendMessageError::SendQueueFull) => {
                             debug!("FetchRequestStage: request send queue is full");
-                            return Some(Ok(()));
+                            return ControlFlow::Break(Ok(()));
                         }
-                        Some(SendMessageError::ReactorStopped) => return Some(Err(error)),
-                        None => return Some(Err(error)),
+                        Some(SendMessageError::ReactorStopped) => {
+                            return ControlFlow::Break(Err(error))
+                        }
+                        None => return ControlFlow::Break(Err(error)),
                     },
                     Ok(_) => {
                         let mut slice = RwLockUpgradableReadGuard::upgrade(slice);
@@ -101,8 +103,14 @@ impl FetchRequestStage {
                     }
                 }
             }
-            None
-        })
+            ControlFlow::Continue(())
+        });
+
+        if let ControlFlow::Break(break_result) = result {
+            break_result
+        } else {
+            Ok(())
+        }
     }
 
     fn request(

--- a/src/downloader/headers/penalize_stage.rs
+++ b/src/downloader/headers/penalize_stage.rs
@@ -43,7 +43,7 @@ impl PenalizeStage {
             bad_peers
         );
         self.penalize_peers(bad_peers).await?;
-        self.reset_pending()?;
+        self.reset_pending();
 
         debug!("PenalizeStage: done");
         Ok(())
@@ -59,12 +59,11 @@ impl PenalizeStage {
                     None => warn!("PenalizeStage: got an invalid headers slice from an unknown peer starting at: {:?}", slice.start_block_num),
                 }
             }
-            None
-        })?;
+        });
         Ok(peers)
     }
 
-    fn reset_pending(&self) -> anyhow::Result<()> {
+    fn reset_pending(&self) {
         self.header_slices.for_each(|slice_lock| {
             let slice = slice_lock.upgradable_read();
             if slice.status == HeaderSliceStatus::Invalid {
@@ -73,8 +72,7 @@ impl PenalizeStage {
                     .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Empty);
                 slice.headers = None;
             }
-            None
-        })
+        });
     }
 
     async fn penalize_peers(&self, peers: HashSet<PeerId>) -> anyhow::Result<()> {

--- a/src/downloader/headers/retry_stage.rs
+++ b/src/downloader/headers/retry_stage.rs
@@ -55,8 +55,7 @@ impl RetryStage {
                     .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Empty);
                 count += 1;
             }
-            None
-        })?;
+        });
         Ok(count)
     }
 

--- a/src/downloader/headers/verify_stage_linear.rs
+++ b/src/downloader/headers/verify_stage_linear.rs
@@ -42,12 +42,12 @@ impl VerifyStageLinear {
             "VerifyStageLinear: verifying {} slices",
             self.pending_watch.pending_count()
         );
-        self.verify_pending()?;
+        self.verify_pending();
         debug!("VerifyStageLinear: done");
         Ok(())
     }
 
-    fn verify_pending(&self) -> anyhow::Result<()> {
+    fn verify_pending(&self) {
         self.header_slices.for_each(|slice_lock| {
             let slice = slice_lock.upgradable_read();
             if slice.status == HeaderSliceStatus::Downloaded {
@@ -62,8 +62,7 @@ impl VerifyStageLinear {
                         .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Invalid);
                 }
             }
-            None
-        })
+        });
     }
 
     fn now_timestamp() -> u64 {

--- a/src/downloader/headers/verify_stage_preverified.rs
+++ b/src/downloader/headers/verify_stage_preverified.rs
@@ -39,12 +39,12 @@ impl VerifyStagePreverified {
             "VerifyStagePreverified: verifying {} slices",
             self.pending_watch.pending_count()
         );
-        self.verify_pending()?;
+        self.verify_pending();
         debug!("VerifyStagePreverified: done");
         Ok(())
     }
 
-    fn verify_pending(&self) -> anyhow::Result<()> {
+    fn verify_pending(&self) {
         self.header_slices.for_each(|slice_lock| {
             let slice = slice_lock.upgradable_read();
             if slice.status == HeaderSliceStatus::Downloaded {
@@ -59,8 +59,7 @@ impl VerifyStagePreverified {
                         .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Invalid);
                 }
             }
-            None
-        })
+        });
     }
 
     /// The algorithm verifies that the edges of the slice match to the preverified hashes,


### PR DESCRIPTION
The logic was based on indexes, but they are not stable
since save_slice() is async, RefillStage might or might not trigger
in between and remove the saved slices.

Also it was possible to not have RefillStage call between SaveStage calls.
In this case we've got Saved status at front, and confused it with a non-monotonic case.

Fixed by searching for the next slice in each loop iteration,
skipping already processed ones.