### PR TITLE
Akula: fix panic without data dir in toolbox.

### DIFF
--- a/bin/akula-toolbox.rs
+++ b/bin/akula-toolbox.rs
@@ -93,6 +93,7 @@ pub struct HeaderDownloadOpts {
 }
 
 async fn blockhashes(data_dir: AkulaDataDir) -> anyhow::Result<()> {
+    std::fs::create_dir_all(&data_dir.0)?;
     let env = akula::MdbxEnvironment::<mdbx::NoWriteMap>::open_rw(
         mdbx::Environment::new(),
         &data_dir.chain_data_dir(),
@@ -130,6 +131,7 @@ async fn header_download(data_dir: AkulaDataDir, opts: HeaderDownloadOpts) -> an
         sentry_status_provider,
     )?;
 
+    std::fs::create_dir_all(&data_dir.0)?;
     let db = akula::kv::new_database(&data_dir.chain_data_dir())?;
 
     let mut staged_sync = stagedsync::StagedSync::new();

--- a/bin/akula.rs
+++ b/bin/akula.rs
@@ -455,8 +455,8 @@ async fn main() -> anyhow::Result<()> {
         None
     };
 
-    let akula_chain_data_dir = opt.data_dir.chain_data_dir();
     std::fs::create_dir_all(&opt.data_dir.0)?;
+    let akula_chain_data_dir = opt.data_dir.chain_data_dir();
     let db = akula::kv::new_database(&akula_chain_data_dir)?;
     async {
         let txn = db.begin_mutable().await?;


### PR DESCRIPTION
Make sure that the data_dir exists before trying to
create/open a writable database inside data_dir/chaindata.