### PR TITLE
Downloader: load preverified hashes config once.

### DIFF
--- a/bin/akula-toolbox.rs
+++ b/bin/akula-toolbox.rs
@@ -128,7 +128,8 @@ async fn header_download(data_dir: AkulaDataDir, opts: HeaderDownloadOpts) -> an
         opts.downloader_opts.headers_batch_size,
         sentry.clone(),
         sentry_status_provider,
-    );
+    )?;
+
     let db = akula::kv::new_database(&data_dir.chain_data_dir())?;
 
     let mut staged_sync = stagedsync::StagedSync::new();

--- a/bin/akula.rs
+++ b/bin/akula.rs
@@ -466,7 +466,7 @@ async fn main() -> anyhow::Result<()> {
             opt.downloader_opts.headers_batch_size,
             sentry,
             sentry_status_provider,
-        ));
+        )?);
         // also add body download stage here
     }
     staged_sync.push(BlockHashes);

--- a/src/downloader/downloader_tests.rs
+++ b/src/downloader/downloader_tests.rs
@@ -72,6 +72,7 @@ async fn noop() {
         byte_unit::n_mib_bytes!(50) as usize,
         sentry_reactor.clone(),
         status_provider,
-    );
+    )
+    .unwrap();
     run_downloader(downloader, sentry_reactor).await.unwrap();
 }

--- a/src/downloader/headers/downloader_preverified.rs
+++ b/src/downloader/headers/downloader_preverified.rs
@@ -12,22 +12,21 @@ use crate::{
             header_slices::align_block_num_to_slice_start,
             stage_stream::{make_stage_stream, StageStream},
         },
-        ui_system::{UISystem, UISystemViewScope},
+        ui_system::{UISystemShared, UISystemViewScope},
     },
     kv,
     models::BlockNumber,
     sentry::sentry_client_reactor::*,
 };
 use std::sync::Arc;
-use tokio::sync::Mutex;
 use tokio_stream::{StreamExt, StreamMap};
 use tracing::*;
 
+#[derive(Debug)]
 pub struct DownloaderPreverified {
     preverified_hashes_config: PreverifiedHashesConfig,
     mem_limit: usize,
     sentry: SentryClientReactorShared,
-    ui_system: Arc<Mutex<UISystem>>,
 }
 
 pub struct DownloaderPreverifiedReport {
@@ -42,7 +41,6 @@ impl DownloaderPreverified {
         chain_name: String,
         mem_limit: usize,
         sentry: SentryClientReactorShared,
-        ui_system: Arc<Mutex<UISystem>>,
     ) -> anyhow::Result<Self> {
         let preverified_hashes_config = PreverifiedHashesConfig::new(&chain_name)?;
 
@@ -50,7 +48,6 @@ impl DownloaderPreverified {
             preverified_hashes_config,
             mem_limit,
             sentry,
-            ui_system,
         };
         Ok(instance)
     }
@@ -65,6 +62,7 @@ impl DownloaderPreverified {
         db_transaction: &'downloader RwTx,
         start_block_num: BlockNumber,
         max_blocks_count: usize,
+        ui_system: UISystemShared,
     ) -> anyhow::Result<DownloaderPreverifiedReport> {
         let start_block_num = align_block_num_to_slice_start(start_block_num);
         let target_final_block_num = self.target_final_block_num();
@@ -95,7 +93,7 @@ impl DownloaderPreverified {
         let header_slices_view =
             HeaderSlicesView::new(header_slices.clone(), "DownloaderPreverified");
         let _header_slices_view_scope =
-            UISystemViewScope::new(&self.ui_system, Box::new(header_slices_view));
+            UISystemViewScope::new(&ui_system, Box::new(header_slices_view));
 
         // Downloading happens with several stages where
         // each of the stages processes blocks in one status,

--- a/src/downloader/headers/preverified_hashes_config.rs
+++ b/src/downloader/headers/preverified_hashes_config.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 /// The preverified hashes are copied from:
 /// https://github.com/ledgerwatch/erigon/blob/devel/turbo/stages/headerdownload/preverified_hashes_mainnet.go
 /// https://github.com/ledgerwatch/erigon/blob/devel/turbo/stages/headerdownload/preverified_hashes_ropsten.go
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PreverifiedHashesConfig {
     pub hashes: Vec<ethereum_types::H256>,
 }

--- a/src/downloader/ui_system.rs
+++ b/src/downloader/ui_system.rs
@@ -14,6 +14,8 @@ pub struct UISystem {
     stop_signal_sender: mpsc::Sender<()>,
 }
 
+pub type UISystemShared = Arc<tokio::sync::Mutex<UISystem>>;
+
 pub struct UISystemViewScope {
     ui_system: Arc<AsyncMutex<UISystem>>,
 }

--- a/src/stages/downloader.rs
+++ b/src/stages/downloader.rs
@@ -25,14 +25,15 @@ impl HeaderDownload {
         batch_size: usize,
         sentry: SentryClientReactorShared,
         sentry_status_provider: SentryStatusProvider,
-    ) -> Self {
-        let downloader = Downloader::new(chain_config, mem_limit, sentry, sentry_status_provider);
+    ) -> anyhow::Result<Self> {
+        let downloader = Downloader::new(chain_config, mem_limit, sentry, sentry_status_provider)?;
 
-        Self {
+        let instance = Self {
             downloader,
             batch_size,
             previous_run_state: Arc::new(AsyncMutex::new(None)),
-        }
+        };
+        Ok(instance)
     }
 
     async fn load_previous_run_state(&self) -> Option<HeaderDownloaderRunState> {


### PR DESCRIPTION
This is a low-hanging fruit optimization.
PreverifiedHashesConfig was read multiple times (each time the stage was run),
and it accounted for 3% of time.

