### PR TITLE
Downloader: fix verify_pending congestion.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "modular-bitfield",
  "num-bigint",
  "num-traits",
+ "num_cpus",
  "once_cell",
  "parking_lot",
  "pin-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ maplit = "1"
 mdbx = { package = "libmdbx", version = "0.1" }
 modular-bitfield = "0.11"
 num-bigint = "0.4"
+num_cpus = "1.13"
 num-traits = "0.2"
 once_cell = "1"
 parking_lot = "0.11"

--- a/src/downloader/headers/header_slices.rs
+++ b/src/downloader/headers/header_slices.rs
@@ -176,6 +176,25 @@ impl HeaderSlices {
             .map(Arc::clone)
     }
 
+    pub fn find_batch_by_status(
+        &self,
+        status: HeaderSliceStatus,
+        batch_size: usize,
+    ) -> Vec<Arc<RwLock<HeaderSlice>>> {
+        let mut batch = Vec::new();
+        let slices = self.slices.read();
+        for slice_lock in slices.iter() {
+            let slice = slice_lock.read();
+            if slice.status == status {
+                batch.push(slice_lock.clone());
+                if batch.len() == batch_size {
+                    break;
+                }
+            }
+        }
+        batch
+    }
+
     pub fn remove(&self, status: HeaderSliceStatus) {
         let mut slices = self.slices.write();
         let mut cursor = slices.cursor_front_mut();

--- a/src/downloader/headers/mod.rs
+++ b/src/downloader/headers/mod.rs
@@ -4,6 +4,7 @@ mod downloader_linear;
 mod downloader_preverified;
 mod header_slice_status_watch;
 pub mod header_slices;
+mod parallel;
 pub mod stage;
 mod stage_stream;
 

--- a/src/downloader/headers/parallel.rs
+++ b/src/downloader/headers/parallel.rs
@@ -1,0 +1,28 @@
+use tokio::task::JoinHandle;
+
+unsafe fn extend_lifetime<'f, T, R>(
+    func: Box<dyn Fn(T) -> R + Send + 'f>,
+) -> Box<dyn Fn(T) -> R + Send + 'static> {
+    std::mem::transmute::<_, Box<dyn Fn(T) -> R + Send + 'static>>(func)
+}
+
+pub async fn map_parallel<'f, T, R, F>(items: Vec<T>, func: F) -> Vec<R>
+where
+    T: Send + 'static,
+    R: Send + 'static,
+    F: Fn(T) -> R + Send + Copy + 'f,
+{
+    let handles = Vec::<JoinHandle<R>>::from_iter(items.into_iter().map(|item| {
+        // SAFETY: task_func is only used within the task,
+        // and the task is joined at the end of this async function,
+        // at which point func is still alive.
+        let task_func = unsafe { extend_lifetime(Box::new(func)) };
+        tokio::spawn(async move { task_func(item) })
+    }));
+
+    let mut results = Vec::<R>::new();
+    for handle in handles {
+        results.push(handle.await.unwrap())
+    }
+    results
+}

--- a/src/downloader/headers/verify_stage_preverified.rs
+++ b/src/downloader/headers/verify_stage_preverified.rs
@@ -1,10 +1,11 @@
-use crate::downloader::headers::{
+use super::{
     header_slice_status_watch::HeaderSliceStatusWatch,
     header_slice_verifier, header_slices,
     header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices},
+    parallel::map_parallel,
     preverified_hashes_config::PreverifiedHashesConfig,
 };
-use parking_lot::RwLockUpgradableReadGuard;
+use parking_lot::RwLock;
 use std::{ops::DerefMut, sync::Arc};
 use tracing::*;
 
@@ -39,18 +40,26 @@ impl VerifyStagePreverified {
             "VerifyStagePreverified: verifying {} slices",
             self.pending_watch.pending_count()
         );
-        self.verify_pending();
+        self.verify_pending().await;
         debug!("VerifyStagePreverified: done");
         Ok(())
     }
 
-    fn verify_pending(&self) {
-        self.header_slices.for_each(|slice_lock| {
-            let slice = slice_lock.upgradable_read();
-            if slice.status == HeaderSliceStatus::Downloaded {
-                let is_verified = self.verify_slice(&slice);
+    async fn verify_pending(&self) {
+        loop {
+            let slices_batch = self
+                .header_slices
+                .find_batch_by_status(HeaderSliceStatus::Downloaded, num_cpus::get());
+            if slices_batch.is_empty() {
+                break;
+            }
 
-                let mut slice = RwLockUpgradableReadGuard::upgrade(slice);
+            let slices_verified = self.verify_slices_parallel(&slices_batch).await;
+
+            for (i, slice_lock) in slices_batch.iter().enumerate() {
+                let mut slice = slice_lock.write();
+                let is_verified = slices_verified[i];
+
                 if is_verified {
                     self.header_slices
                         .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Verified);
@@ -59,7 +68,15 @@ impl VerifyStagePreverified {
                         .set_slice_status(slice.deref_mut(), HeaderSliceStatus::Invalid);
                 }
             }
-        });
+        }
+    }
+
+    async fn verify_slices_parallel(&self, slices: &[Arc<RwLock<HeaderSlice>>]) -> Vec<bool> {
+        map_parallel(Vec::from(slices), |slice_lock| -> bool {
+            let slice = slice_lock.write();
+            self.verify_slice(&slice)
+        })
+        .await
     }
 
     /// The algorithm verifies that the edges of the slice match to the preverified hashes,


### PR DESCRIPTION
verify_pending locks the header_slices for too long inside for_each.
Unlock it more often for each batch of slices,
and process this batch in parallel.

This saves 15% of the overall time.