### PR TITLE
Downloader: cache hash() result.

### DIFF
--- a/src/downloader/headers/header_slice_verifier.rs
+++ b/src/downloader/headers/header_slice_verifier.rs
@@ -6,9 +6,9 @@ use crate::{
     },
 };
 
-pub fn verify_link_by_parent_hash(child: &BlockHeader, parent: &BlockHeader) -> bool {
+pub fn verify_link_by_parent_hash(child: &BlockHeader, parent: &mut BlockHeader) -> bool {
     let given_parent_hash = child.parent_hash;
-    let expected_parent_hash = parent.hash();
+    let expected_parent_hash = parent.hash_cached();
     given_parent_hash == expected_parent_hash
 }
 
@@ -74,9 +74,17 @@ fn enumerate_sequential_pairs(
 }
 
 /// Verify that all blocks in the slice are linked by the parent_hash field.
-pub fn verify_slice_is_linked_by_parent_hash(headers: &[BlockHeader]) -> bool {
-    enumerate_sequential_pairs(headers)
-        .all(|(parent, child)| verify_link_by_parent_hash(child, parent))
+pub fn verify_slice_is_linked_by_parent_hash(headers: &mut [BlockHeader]) -> bool {
+    for parent_index in 0..headers.len() - 1 {
+        let mut it = headers.iter_mut().skip(parent_index);
+        let parent = it.next().unwrap();
+        let child = it.next().unwrap();
+
+        if !verify_link_by_parent_hash(child, parent) {
+            return false;
+        }
+    }
+    true
 }
 
 /// Verify that block numbers start from the expected

--- a/src/downloader/headers/save_stage.rs
+++ b/src/downloader/headers/save_stage.rs
@@ -125,9 +125,9 @@ impl<'tx, 'db: 'tx, RwTx: MutableTransaction<'db>> SaveStage<'tx, RwTx> {
         Ok(())
     }
 
-    async fn save_header(&self, header: BlockHeader, tx: &RwTx) -> anyhow::Result<()> {
+    async fn save_header(&self, mut header: BlockHeader, tx: &RwTx) -> anyhow::Result<()> {
         let block_num = header.number;
-        let header_hash = header.hash();
+        let header_hash = header.hash_cached();
         let header_key: HeaderKey = (block_num, header_hash);
         let total_difficulty = header.difficulty;
 

--- a/src/downloader/headers/verify_stage_linear.rs
+++ b/src/downloader/headers/verify_stage_linear.rs
@@ -75,8 +75,8 @@ impl VerifyStageLinear {
 
     async fn verify_slices_parallel(&self, slices: &[Arc<RwLock<HeaderSlice>>]) -> Vec<bool> {
         map_parallel(Vec::from(slices), |slice_lock| -> bool {
-            let slice = slice_lock.write();
-            self.verify_slice(&slice)
+            let mut slice = slice_lock.write();
+            self.verify_slice(&mut slice)
         })
         .await
     }
@@ -88,11 +88,11 @@ impl VerifyStageLinear {
             .as_secs()
     }
 
-    fn verify_slice(&self, slice: &HeaderSlice) -> bool {
+    fn verify_slice(&self, slice: &mut HeaderSlice) -> bool {
         if slice.headers.is_none() {
             return false;
         }
-        let headers = slice.headers.as_ref().unwrap();
+        let headers = slice.headers.as_mut().unwrap();
         if headers.len() != self.slice_size {
             return false;
         }

--- a/src/downloader/headers/verify_stage_linear_link.rs
+++ b/src/downloader/headers/verify_stage_linear_link.rs
@@ -102,7 +102,7 @@ impl VerifyStageLinearLink {
     fn verify_pending_slice(&mut self, slice_lock: Arc<RwLock<HeaderSlice>>) -> bool {
         let slice = slice_lock.upgradable_read();
 
-        let is_verified = self.verify_slice_link(&slice, &self.last_verified_header);
+        let is_verified = self.verify_slice_link(&slice, self.last_verified_header.clone());
 
         let mut slice = RwLockUpgradableReadGuard::upgrade(slice);
         if is_verified {
@@ -126,7 +126,7 @@ impl VerifyStageLinearLink {
             .as_secs()
     }
 
-    fn verify_slice_link(&self, slice: &HeaderSlice, parent: &Option<BlockHeader>) -> bool {
+    fn verify_slice_link(&self, slice: &HeaderSlice, parent: Option<BlockHeader>) -> bool {
         if slice.headers.is_none() {
             return false;
         }
@@ -144,7 +144,7 @@ impl VerifyStageLinearLink {
         if parent.is_none() {
             return false;
         }
-        let parent = parent.as_ref().unwrap();
+        let parent = &mut parent.unwrap();
 
         header_slice_verifier::verify_link_by_parent_hash(child, parent)
             && header_slice_verifier::verify_link_block_nums(child, parent)

--- a/src/downloader/headers/verify_stage_preverified.rs
+++ b/src/downloader/headers/verify_stage_preverified.rs
@@ -73,8 +73,8 @@ impl VerifyStagePreverified {
 
     async fn verify_slices_parallel(&self, slices: &[Arc<RwLock<HeaderSlice>>]) -> Vec<bool> {
         map_parallel(Vec::from(slices), |slice_lock| -> bool {
-            let slice = slice_lock.write();
-            self.verify_slice(&slice)
+            let mut slice = slice_lock.write();
+            self.verify_slice(&mut slice)
         })
         .await
     }
@@ -93,11 +93,11 @@ impl VerifyStagePreverified {
     /// hash(slice[192]) == preverified hash(192)
     ///
     /// Thus verifying hashes of all the headers.
-    fn verify_slice(&self, slice: &HeaderSlice) -> bool {
+    fn verify_slice(&self, slice: &mut HeaderSlice) -> bool {
         if slice.headers.is_none() {
             return false;
         }
-        let headers = slice.headers.as_ref().unwrap();
+        let headers = slice.headers.as_mut().unwrap();
 
         if headers.is_empty() {
             return false;

--- a/src/models/block.rs
+++ b/src/models/block.rs
@@ -322,6 +322,7 @@ mod tests {
                     .into(),
                 nonce: hex!("68b769c5451a7aea").into(),
                 base_fee_per_gas: None,
+                hash_cached: None,
             }]
         );
 
@@ -397,6 +398,7 @@ mod tests {
                     .into(),
                 nonce: hex!("0000000000000023").into(),
                 base_fee_per_gas: None,
+                hash_cached: None,
             }],
         };
 

--- a/src/models/header.rs
+++ b/src/models/header.rs
@@ -24,6 +24,9 @@ pub struct BlockHeader {
     pub mix_hash: H256,
     pub nonce: H64,
     pub base_fee_per_gas: Option<U256>,
+
+    #[serde(skip_serializing)]
+    pub hash_cached: Option<H256>,
 }
 
 impl Encodable for BlockHeader {
@@ -97,6 +100,7 @@ impl Decodable for BlockHeader {
             mix_hash,
             nonce,
             base_fee_per_gas,
+            hash_cached: None,
         })
     }
 }
@@ -121,6 +125,7 @@ impl BlockHeader {
             mix_hash: partial_header.mix_hash,
             nonce: partial_header.nonce,
             base_fee_per_gas: partial_header.base_fee_per_gas,
+            hash_cached: None,
         }
     }
 
@@ -143,12 +148,23 @@ impl BlockHeader {
             mix_hash: H256::zero(),
             nonce: H64::zero(),
             base_fee_per_gas: None,
+            hash_cached: None,
         }
     }
 
     #[must_use]
     pub fn hash(&self) -> H256 {
         keccak256(&rlp::encode(self)[..])
+    }
+
+    pub fn hash_cached(&mut self) -> H256 {
+        let hash = self.hash_cached.unwrap_or_else(|| self.hash());
+        self.hash_cached = Some(hash);
+        hash
+    }
+
+    pub fn hash_cached_clear(&mut self) {
+        self.hash_cached = None;
     }
 }
 

--- a/src/state/genesis.rs
+++ b/src/state/genesis.rs
@@ -56,6 +56,8 @@ impl GenesisState {
             receipts_root: EMPTY_ROOT,
             ommers_hash: EMPTY_LIST_HASH,
             transactions_root: EMPTY_ROOT,
+
+            hash_cached: None,
         }
     }
 }
@@ -110,6 +112,8 @@ where
         receipts_root: EMPTY_ROOT,
         ommers_hash: EMPTY_LIST_HASH,
         transactions_root: EMPTY_ROOT,
+
+        hash_cached: None,
     };
     let block_hash = header.hash();
 


### PR DESCRIPTION
This caches the hash() to avoid the 2nd recomputation in SaveStage.
Previously it was computed twice:
1. In VerifyStage to connect hash(parent) to child.parent_hash;
2. In SaveStage to obtain a HeaderKey for saving.

With this caching it saves about 17% of header downloader running time:
![Screenshot 2021-12-13 at 19 36 04](https://user-images.githubusercontent.com/11477595/145869558-7afc5205-23e5-49a4-8e8b-af5394a829d2.png)

This bumps the max speed from about 4-5K blocks/sec to about 5-6K blocks/sec,
which translates to about 10-15 minutes saving on mainnet.
