### PR TITLE
Downloader: refactor header.

### DIFF
--- a/src/downloader/headers/fetch_receive_stage.rs
+++ b/src/downloader/headers/fetch_receive_stage.rs
@@ -1,14 +1,12 @@
-use crate::{
-    downloader::headers::{
-        header_slices,
-        header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices},
-    },
-    models::BlockHeader as Header,
-    sentry::{
-        messages::{BlockHeadersMessage, EthMessageId, Message},
-        sentry_client::PeerId,
-        sentry_client_reactor::*,
-    },
+use super::{
+    header::BlockHeader,
+    header_slices,
+    header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices},
+};
+use crate::sentry::{
+    messages::{BlockHeadersMessage, EthMessageId, Message},
+    sentry_client::PeerId,
+    sentry_client_reactor::*,
 };
 use futures_core::Stream;
 use std::{
@@ -83,6 +81,8 @@ impl FetchReceiveStage {
                 let slice_status = slice.status;
                 if slice_status == HeaderSliceStatus::Waiting {
                     let from_peer_id = message_from_peer.from_peer_id;
+                    let headers: Vec<BlockHeader> =
+                        headers.into_iter().map(BlockHeader::from).collect();
                     self.update_slice(slice.deref_mut(), headers, from_peer_id);
                 } else {
                     debug!("FetchReceiveStage ignores a headers slice that we didn't request starting at: {:?}; status = {:?}", start_block_num, slice_status);
@@ -100,7 +100,7 @@ impl FetchReceiveStage {
     fn update_slice(
         &self,
         slice: &mut HeaderSlice,
-        headers: Vec<Header>,
+        headers: Vec<BlockHeader>,
         from_peer_id: Option<PeerId>,
     ) {
         slice.headers = Some(headers);

--- a/src/downloader/headers/header.rs
+++ b/src/downloader/headers/header.rs
@@ -1,0 +1,34 @@
+use crate::models;
+use ethereum_types::{H256, U256};
+
+#[derive(Clone, Debug)]
+pub struct BlockHeader {
+    pub header: models::BlockHeader,
+}
+
+impl BlockHeader {
+    pub fn difficulty(&self) -> U256 {
+        self.header.difficulty
+    }
+    pub fn number(&self) -> models::BlockNumber {
+        self.header.number
+    }
+    pub fn ommers_hash(&self) -> H256 {
+        self.header.ommers_hash
+    }
+    pub fn parent_hash(&self) -> H256 {
+        self.header.parent_hash
+    }
+    pub fn timestamp(&self) -> u64 {
+        self.header.timestamp
+    }
+    pub fn hash(&self) -> H256 {
+        self.header.hash()
+    }
+}
+
+impl From<models::BlockHeader> for BlockHeader {
+    fn from(header: models::BlockHeader) -> Self {
+        Self { header }
+    }
+}

--- a/src/downloader/headers/header_slice_verifier.rs
+++ b/src/downloader/headers/header_slice_verifier.rs
@@ -1,26 +1,24 @@
+use super::header::BlockHeader;
 use crate::{
     consensus::difficulty::{canonical_difficulty, BlockDifficultyBombData},
-    models::{
-        switch_is_active, BlockHeader, BlockNumber, ChainSpec, SealVerificationParams,
-        EMPTY_LIST_HASH,
-    },
+    models::{switch_is_active, BlockNumber, ChainSpec, SealVerificationParams, EMPTY_LIST_HASH},
 };
 
 pub fn verify_link_by_parent_hash(child: &BlockHeader, parent: &BlockHeader) -> bool {
-    let given_parent_hash = child.parent_hash;
+    let given_parent_hash = child.parent_hash();
     let expected_parent_hash = parent.hash();
     given_parent_hash == expected_parent_hash
 }
 
 pub fn verify_link_block_nums(child: &BlockHeader, parent: &BlockHeader) -> bool {
-    let given_block_num = child.number.0;
-    let expected_block_num = parent.number.0 + 1;
+    let given_block_num = child.number().0;
+    let expected_block_num = parent.number().0 + 1;
     given_block_num == expected_block_num
 }
 
 pub fn verify_link_timestamps(child: &BlockHeader, parent: &BlockHeader) -> bool {
-    let parent_timestamp = parent.timestamp;
-    let child_timestamp = child.timestamp;
+    let parent_timestamp = parent.timestamp();
+    let child_timestamp = child.timestamp();
     parent_timestamp < child_timestamp
 }
 
@@ -42,19 +40,19 @@ pub fn verify_link_difficulties(
             }
         };
 
-    let given_child_difficulty = child.difficulty;
+    let given_child_difficulty = child.difficulty();
     let expected_child_difficulty = canonical_difficulty(
-        child.number,
-        child.timestamp,
-        parent.difficulty,
-        parent.timestamp,
-        parent.ommers_hash != EMPTY_LIST_HASH,
-        switch_is_active(byzantium_formula, child.number),
-        switch_is_active(homestead_formula, child.number),
+        child.number(),
+        child.timestamp(),
+        parent.difficulty(),
+        parent.timestamp(),
+        parent.ommers_hash() != EMPTY_LIST_HASH,
+        switch_is_active(byzantium_formula, child.number()),
+        switch_is_active(homestead_formula, child.number()),
         difficulty_bomb
             .as_ref()
             .map(|bomb| BlockDifficultyBombData {
-                delay_to: bomb.get_delay_to(child.number),
+                delay_to: bomb.get_delay_to(child.number()),
             }),
     );
     given_child_difficulty == expected_child_difficulty
@@ -94,7 +92,7 @@ pub fn verify_slice_block_nums(headers: &[BlockHeader], start_block_num: BlockNu
 
     // verify the first block number
     let first = &headers[0];
-    let first_block_num = first.number;
+    let first_block_num = first.number();
     first_block_num == start_block_num
 }
 
@@ -111,7 +109,7 @@ pub fn verify_slice_timestamps(headers: &[BlockHeader], max_timestamp: u64) -> b
     }
 
     let last = headers.last().unwrap();
-    let last_timestamp = last.timestamp;
+    let last_timestamp = last.timestamp();
     last_timestamp < max_timestamp
 }
 

--- a/src/downloader/headers/header_slices.rs
+++ b/src/downloader/headers/header_slices.rs
@@ -1,7 +1,5 @@
-use crate::{
-    models::{BlockHeader as Header, BlockNumber},
-    sentry::sentry_client::PeerId,
-};
+use super::header::BlockHeader;
+use crate::{models::BlockNumber, sentry::sentry_client::PeerId};
 use parking_lot::RwLock;
 use std::{
     collections::{HashMap, VecDeque},
@@ -35,7 +33,7 @@ pub enum HeaderSliceStatus {
 pub struct HeaderSlice {
     pub start_block_num: BlockNumber,
     pub status: HeaderSliceStatus,
-    pub headers: Option<Vec<Header>>,
+    pub headers: Option<Vec<BlockHeader>>,
     pub from_peer_id: Option<PeerId>,
     pub request_time: Option<time::Instant>,
     pub request_attempt: u16,
@@ -72,7 +70,7 @@ impl HeaderSlices {
         start_block_num: BlockNumber,
         final_block_num: BlockNumber,
     ) -> Self {
-        let max_slices = mem_limit / std::mem::size_of::<Header>() / HEADER_SLICE_SIZE;
+        let max_slices = mem_limit / std::mem::size_of::<BlockHeader>() / HEADER_SLICE_SIZE;
 
         assert_eq!(
             (start_block_num.0 as usize) % HEADER_SLICE_SIZE,

--- a/src/downloader/headers/mod.rs
+++ b/src/downloader/headers/mod.rs
@@ -2,6 +2,7 @@ mod average_delta_counter;
 pub mod downloader;
 mod downloader_linear;
 mod downloader_preverified;
+mod header;
 mod header_slice_status_watch;
 pub mod header_slices;
 mod parallel;

--- a/src/downloader/headers/verify_stage_linear_link.rs
+++ b/src/downloader/headers/verify_stage_linear_link.rs
@@ -1,12 +1,10 @@
-use crate::{
-    downloader::headers::{
-        header_slice_status_watch::HeaderSliceStatusWatch,
-        header_slice_verifier,
-        header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices},
-    },
-    models::{BlockHeader, BlockNumber},
-    sentry::chain_config::ChainConfig,
+use super::{
+    header::BlockHeader,
+    header_slice_status_watch::HeaderSliceStatusWatch,
+    header_slice_verifier,
+    header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices},
 };
+use crate::{models::BlockNumber, sentry::chain_config::ChainConfig};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use std::{
     ops::{ControlFlow, DerefMut},
@@ -137,7 +135,7 @@ impl VerifyStageLinearLink {
         let child = &headers[0];
 
         // for the start header we just verify its hash
-        if child.number == self.start_block_num {
+        if child.number() == self.start_block_num {
             return child.hash() == self.start_block_hash;
         }
         // otherwise we expect that we have a verified parent


### PR DESCRIPTION
Use a BlockHeader wrapper instead of models directly.