### PR TITLE
Downloader: cache hash() v2 (inside downloader).

### DIFF
--- a/src/downloader/headers/header.rs
+++ b/src/downloader/headers/header.rs
@@ -1,9 +1,12 @@
-use crate::models;
+use crate::{crypto::keccak256, models};
+use bytes::BytesMut;
 use ethereum_types::{H256, U256};
 
 #[derive(Clone, Debug)]
 pub struct BlockHeader {
     pub header: models::BlockHeader,
+    rlp_repr_cached: Option<BytesMut>,
+    hash_cached: Option<H256>,
 }
 
 impl BlockHeader {
@@ -22,13 +25,47 @@ impl BlockHeader {
     pub fn timestamp(&self) -> u64 {
         self.header.timestamp
     }
+
+    fn rlp_repr_compute(&self) -> BytesMut {
+        rlp::encode(&self.header)
+    }
+
+    pub fn rlp_repr_prepare(&mut self) {
+        self.rlp_repr_cached = Some(self.rlp_repr_compute());
+    }
+
+    pub fn rlp_repr(&self) -> BytesMut {
+        self.rlp_repr_cached
+            .clone()
+            .unwrap_or_else(|| self.rlp_repr_compute())
+    }
+
+    fn hash_compute(rlp_repr: &BytesMut) -> H256 {
+        keccak256(rlp_repr.as_ref())
+    }
+
+    pub fn hash_prepare(&mut self) {
+        if self.rlp_repr_cached.is_none() {
+            self.rlp_repr_prepare();
+        }
+        // Not calling self.rlp_repr(), because it causes an extra clone,
+        // but we just need a ref here.
+        let rlp_repr_cached = self.rlp_repr_cached.as_ref().unwrap();
+        self.hash_cached = Some(Self::hash_compute(rlp_repr_cached))
+    }
+
     pub fn hash(&self) -> H256 {
-        self.header.hash()
+        self.hash_cached
+            .unwrap_or_else(|| Self::hash_compute(&self.rlp_repr()))
     }
 }
 
 impl From<models::BlockHeader> for BlockHeader {
     fn from(header: models::BlockHeader) -> Self {
-        Self { header }
+        Self {
+            header,
+            rlp_repr_cached: None,
+            hash_cached: None,
+        }
     }
 }

--- a/src/downloader/headers/verify_stage_linear.rs
+++ b/src/downloader/headers/verify_stage_linear.rs
@@ -75,10 +75,19 @@ impl VerifyStageLinear {
 
     async fn verify_slices_parallel(&self, slices: &[Arc<RwLock<HeaderSlice>>]) -> Vec<bool> {
         map_parallel(Vec::from(slices), |slice_lock| -> bool {
-            let slice = slice_lock.write();
+            let mut slice = slice_lock.write();
+            Self::prepare_slice_hashes(&mut slice);
             self.verify_slice(&slice)
         })
         .await
+    }
+
+    fn prepare_slice_hashes(slice: &mut HeaderSlice) {
+        if let Some(headers) = slice.headers.as_mut() {
+            for header in headers {
+                header.hash_prepare();
+            }
+        }
     }
 
     fn now_timestamp() -> u64 {

--- a/src/downloader/headers/verify_stage_preverified.rs
+++ b/src/downloader/headers/verify_stage_preverified.rs
@@ -73,10 +73,19 @@ impl VerifyStagePreverified {
 
     async fn verify_slices_parallel(&self, slices: &[Arc<RwLock<HeaderSlice>>]) -> Vec<bool> {
         map_parallel(Vec::from(slices), |slice_lock| -> bool {
-            let slice = slice_lock.write();
+            let mut slice = slice_lock.write();
+            Self::prepare_slice_hashes(&mut slice);
             self.verify_slice(&slice)
         })
         .await
+    }
+
+    fn prepare_slice_hashes(slice: &mut HeaderSlice) {
+        if let Some(headers) = slice.headers.as_mut() {
+            for header in headers {
+                header.hash_prepare();
+            }
+        }
     }
 
     /// The algorithm verifies that the edges of the slice match to the preverified hashes,


### PR DESCRIPTION
This caches the hash() to avoid the 2nd recomputation in SaveStage.

Previously it was computed twice:
* In VerifyStage to connect hash(parent) to child.parent_hash;
* In SaveStage to obtain a HeaderKey for saving.

With this caching it saves about 17% of header downloader running time:

This bumps the max speed from about 4-5K blocks/sec to about 5-6K blocks/sec,
which translates to about 10-15 minutes saving on mainnet.