### PR TITLE
Downloader: save precomputed header RLP.

### DIFF
--- a/src/downloader/headers/header.rs
+++ b/src/downloader/headers/header.rs
@@ -1,11 +1,11 @@
 use crate::{crypto::keccak256, models};
-use bytes::BytesMut;
+use bytes::Bytes;
 use ethereum_types::{H256, U256};
 
 #[derive(Clone, Debug)]
 pub struct BlockHeader {
     pub header: models::BlockHeader,
-    rlp_repr_cached: Option<BytesMut>,
+    rlp_repr_cached: Option<Bytes>,
     hash_cached: Option<H256>,
 }
 
@@ -26,21 +26,21 @@ impl BlockHeader {
         self.header.timestamp
     }
 
-    fn rlp_repr_compute(&self) -> BytesMut {
-        rlp::encode(&self.header)
+    fn rlp_repr_compute(&self) -> Bytes {
+        rlp::encode(&self.header).freeze()
     }
 
     pub fn rlp_repr_prepare(&mut self) {
         self.rlp_repr_cached = Some(self.rlp_repr_compute());
     }
 
-    pub fn rlp_repr(&self) -> BytesMut {
+    pub fn rlp_repr(&self) -> Bytes {
         self.rlp_repr_cached
             .clone()
             .unwrap_or_else(|| self.rlp_repr_compute())
     }
 
-    fn hash_compute(rlp_repr: &BytesMut) -> H256 {
+    fn hash_compute(rlp_repr: &Bytes) -> H256 {
         keccak256(rlp_repr.as_ref())
     }
 


### PR DESCRIPTION
This reuses precomputed RLP bytes in SaveStage.

Previously it was computed twice:
* In VerifyStage to as a part of computing hash();
* In SaveStage as a part of Table::Value::encode() serialization for saving;

Reusing the RLP bytes saves about 10% of header downloader running time.