### PR TITLE
Downloader: fix linear phase hang if saved to fast.

### DIFF
--- a/src/downloader/headers/verify_stage_linear_link.rs
+++ b/src/downloader/headers/verify_stage_linear_link.rs
@@ -74,7 +74,7 @@ impl VerifyStageLinearLink {
             let next_slice_lock = self.header_slices.try_fold(initial_value, |_, slice_lock| {
                 let slice = slice_lock.read();
                 match slice.status {
-                    HeaderSliceStatus::Verified | HeaderSliceStatus::Invalid => {
+                    HeaderSliceStatus::Verified | HeaderSliceStatus::Saved => {
                         ControlFlow::Continue(None)
                     }
                     HeaderSliceStatus::VerifiedInternally => {


### PR DESCRIPTION
If a slice is verified and saved too fast,
the next slice monotonic verification aborts.
We can't abort on Saved slices, because they will be evicted,
and so the remaining_count won't change (potentially),
causing the VerifyStageLinearLink to wait forever.

It is fine to abort on Invalid, because they are gonna be redownloaded,
verified internally, and the remaining_count will change.