### PR TITLE
Downloader: postpone slice size check.

### DIFF
--- a/src/downloader/headers/downloader_forky.rs
+++ b/src/downloader/headers/downloader_forky.rs
@@ -84,11 +84,7 @@ impl DownloaderForky {
         );
         let fetch_receive_stage = FetchReceiveStage::new(header_slices.clone(), sentry.clone());
         let retry_stage = RetryStage::new(header_slices.clone());
-        let verify_stage = VerifyStageLinear::new(
-            header_slices.clone(),
-            header_slices::HEADER_SLICE_SIZE,
-            self.chain_config.clone(),
-        );
+        let verify_stage = VerifyStageLinear::new(header_slices.clone(), self.chain_config.clone());
         let verify_link_stage = VerifyStageForkyLink::new(
             header_slices.clone(),
             self.chain_config.clone(),

--- a/src/downloader/headers/downloader_linear.rs
+++ b/src/downloader/headers/downloader_linear.rs
@@ -119,11 +119,7 @@ impl DownloaderLinear {
         );
         let fetch_receive_stage = FetchReceiveStage::new(header_slices.clone(), sentry.clone());
         let retry_stage = RetryStage::new(header_slices.clone());
-        let verify_stage = VerifyStageLinear::new(
-            header_slices.clone(),
-            header_slices::HEADER_SLICE_SIZE,
-            self.chain_config.clone(),
-        );
+        let verify_stage = VerifyStageLinear::new(header_slices.clone(), self.chain_config.clone());
         let verify_link_stage = VerifyStageLinearLink::new(
             header_slices.clone(),
             self.chain_config.clone(),

--- a/src/downloader/headers/fetch_receive_stage.rs
+++ b/src/downloader/headers/fetch_receive_stage.rs
@@ -1,6 +1,5 @@
 use super::{
     header::BlockHeader,
-    header_slices,
     header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices},
 };
 use crate::sentry::{
@@ -64,11 +63,8 @@ impl FetchReceiveStage {
         debug!("FetchReceiveStage: received a headers slice");
 
         let headers = message_from_peer.message.headers;
-        if headers.len() < header_slices::HEADER_SLICE_SIZE {
-            warn!(
-                "FetchReceiveStage got a headers slice of a smaller size: {}",
-                headers.len()
-            );
+        if headers.is_empty() {
+            warn!("FetchReceiveStage got an empty slice");
             return;
         }
 

--- a/src/downloader/headers/verify_stage_linear.rs
+++ b/src/downloader/headers/verify_stage_linear.rs
@@ -11,20 +11,14 @@ use tracing::*;
 /// Verifies the block structure and sequence rules in each slice and sets VerifiedInternally status.
 pub struct VerifyStageLinear {
     header_slices: Arc<HeaderSlices>,
-    slice_size: usize,
     chain_config: ChainConfig,
     pending_watch: HeaderSliceStatusWatch,
 }
 
 impl VerifyStageLinear {
-    pub fn new(
-        header_slices: Arc<HeaderSlices>,
-        slice_size: usize,
-        chain_config: ChainConfig,
-    ) -> Self {
+    pub fn new(header_slices: Arc<HeaderSlices>, chain_config: ChainConfig) -> Self {
         Self {
             header_slices: header_slices.clone(),
-            slice_size,
             chain_config,
             pending_watch: HeaderSliceStatusWatch::new(
                 HeaderSliceStatus::Downloaded,
@@ -98,13 +92,9 @@ impl VerifyStageLinear {
     }
 
     fn verify_slice(&self, slice: &HeaderSlice) -> bool {
-        if slice.headers.is_none() {
+        let Some(headers) = slice.headers.as_ref() else {
             return false;
-        }
-        let headers = slice.headers.as_ref().unwrap();
-        if headers.len() != self.slice_size {
-            return false;
-        }
+        };
 
         header_slice_verifier::verify_slice(
             headers,

--- a/src/downloader/headers/verify_stage_linear_link.rs
+++ b/src/downloader/headers/verify_stage_linear_link.rs
@@ -1,7 +1,7 @@
 use super::{
     header::BlockHeader,
     header_slice_status_watch::HeaderSliceStatusWatch,
-    header_slice_verifier,
+    header_slice_verifier, header_slices,
     header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices},
 };
 use crate::{models::BlockNumber, sentry::chain_config::ChainConfig};
@@ -130,13 +130,17 @@ impl VerifyStageLinearLink {
     }
 
     fn verify_slice_link(&self, slice: &HeaderSlice, parent: &Option<BlockHeader>) -> bool {
-        if slice.headers.is_none() {
+        let Some(headers) = slice.headers.as_ref() else {
             return false;
-        }
-        let headers = slice.headers.as_ref().unwrap();
+        };
+
         if headers.is_empty() {
             return false;
         }
+        if headers.len() != header_slices::HEADER_SLICE_SIZE {
+            return false;
+        }
+
         let child = &headers[0];
 
         // for the start header we just verify its hash


### PR DESCRIPTION
In the forky phase we might get partial slices,
but we still want to fetching and internal verification to succeed.