### PR TITLE
Downloader: basic verify link test.

### DIFF
--- a/src/downloader/downloader_impl.rs
+++ b/src/downloader/downloader_impl.rs
@@ -1,6 +1,11 @@
-use super::sentry_status_provider::SentryStatusProvider;
+use super::{
+    headers::{
+        downloader::{DownloaderReport, DownloaderRunState},
+        header_slice_verifier::HeaderSliceVerifier,
+    },
+    sentry_status_provider::SentryStatusProvider,
+};
 use crate::{
-    downloader::headers::downloader::{DownloaderReport, DownloaderRunState},
     kv,
     models::BlockNumber,
     sentry::{chain_config::ChainConfig, sentry_client_reactor::SentryClientReactorShared},
@@ -17,12 +22,13 @@ pub struct Downloader {
 impl Downloader {
     pub fn new(
         chain_config: ChainConfig,
+        verifier: Box<dyn HeaderSliceVerifier>,
         mem_limit: usize,
         sentry: SentryClientReactorShared,
         sentry_status_provider: SentryStatusProvider,
     ) -> anyhow::Result<Self> {
         let headers_downloader =
-            super::headers::downloader::Downloader::new(chain_config, mem_limit, sentry)?;
+            super::headers::downloader::Downloader::new(chain_config, verifier, mem_limit, sentry)?;
 
         let instance = Self {
             headers_downloader,

--- a/src/downloader/headers/downloader_preverified.rs
+++ b/src/downloader/headers/downloader_preverified.rs
@@ -1,16 +1,20 @@
 use super::{
-    downloader_stage_loop::DownloaderStageLoop, fetch_receive_stage::FetchReceiveStage,
-    fetch_request_stage::FetchRequestStage, header_slices, header_slices::HeaderSlices,
-    penalize_stage::PenalizeStage, preverified_hashes_config::PreverifiedHashesConfig,
-    refill_stage::RefillStage, retry_stage::RetryStage, save_stage::SaveStage,
+    downloader_stage_loop::DownloaderStageLoop,
+    fetch_receive_stage::FetchReceiveStage,
+    fetch_request_stage::FetchRequestStage,
+    header_slices,
+    header_slices::{align_block_num_to_slice_start, HeaderSlices},
+    penalize_stage::PenalizeStage,
+    preverified_hashes_config::PreverifiedHashesConfig,
+    refill_stage::RefillStage,
+    retry_stage::RetryStage,
+    save_stage::SaveStage,
     top_block_estimate_stage::TopBlockEstimateStage,
-    verify_stage_preverified::VerifyStagePreverified, HeaderSlicesView,
+    verify_stage_preverified::VerifyStagePreverified,
+    HeaderSlicesView,
 };
 use crate::{
-    downloader::{
-        headers::header_slices::align_block_num_to_slice_start,
-        ui_system::{UISystemShared, UISystemViewScope},
-    },
+    downloader::ui_system::{UISystemShared, UISystemViewScope},
     kv,
     models::BlockNumber,
     sentry::sentry_client_reactor::*,
@@ -106,7 +110,11 @@ impl DownloaderPreverified {
         let refill_stage = RefillStage::new(header_slices.clone());
         let top_block_estimate_stage = TopBlockEstimateStage::new(sentry.clone());
 
-        let can_proceed = fetch_receive_stage.can_proceed_check();
+        let fetch_receive_stage_can_proceed = fetch_receive_stage.can_proceed_check();
+        let refill_stage_can_proceed = refill_stage.can_proceed_check();
+        let can_proceed =
+            move |_| -> bool { fetch_receive_stage_can_proceed() && refill_stage_can_proceed() };
+
         let estimated_top_block_num_provider =
             top_block_estimate_stage.estimated_top_block_num_provider();
 

--- a/src/downloader/headers/downloader_stage_loop.rs
+++ b/src/downloader/headers/downloader_stage_loop.rs
@@ -30,17 +30,14 @@ impl<'s> DownloaderStageLoop<'s> {
         self.stream.insert(name, make_stage_stream(stage));
     }
 
-    pub async fn run(mut self, can_proceed: impl Fn() -> bool) {
+    pub async fn run(mut self, can_proceed: impl Fn(Arc<HeaderSlices>) -> bool) {
         while let Some((key, result)) = self.stream.next().await {
             if result.is_err() {
                 error!("Downloader headers {} failure: {:?}", key, result);
                 break;
             }
 
-            if !can_proceed() {
-                break;
-            }
-            if self.header_slices.is_empty_at_final_position() {
+            if !can_proceed(self.header_slices.clone()) {
                 break;
             }
 

--- a/src/downloader/headers/fetch_request_stage.rs
+++ b/src/downloader/headers/fetch_request_stage.rs
@@ -1,8 +1,8 @@
+use super::{
+    header_slice_status_watch::HeaderSliceStatusWatch,
+    header_slices::{HeaderSliceStatus, HeaderSlices},
+};
 use crate::{
-    downloader::headers::{
-        header_slice_status_watch::HeaderSliceStatusWatch,
-        header_slices::{HeaderSliceStatus, HeaderSlices},
-    },
     models::BlockNumber,
     sentry::{
         block_id,

--- a/src/downloader/headers/header_slice_status_watch.rs
+++ b/src/downloader/headers/header_slice_status_watch.rs
@@ -1,4 +1,4 @@
-use crate::downloader::headers::header_slices::{HeaderSliceStatus, HeaderSlices};
+use super::header_slices::{HeaderSliceStatus, HeaderSlices};
 use std::sync::Arc;
 use tokio::sync::watch;
 use tracing::*;

--- a/src/downloader/headers/header_slice_verifier_mock.rs
+++ b/src/downloader/headers/header_slice_verifier_mock.rs
@@ -1,0 +1,41 @@
+use super::header_slice_verifier::HeaderSliceVerifier;
+use crate::{
+    downloader::headers::header::BlockHeader,
+    models::{BlockNumber, ChainSpec},
+};
+use bytes::Bytes;
+
+#[derive(Debug)]
+pub struct HeaderSliceVerifierMock;
+
+impl HeaderSliceVerifierMock {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn mark_broken_link(&self, child: &mut BlockHeader) {
+        child.header.extra_data = Bytes::from("broken_link");
+    }
+}
+
+impl HeaderSliceVerifier for HeaderSliceVerifierMock {
+    fn verify_link(
+        &self,
+        child: &BlockHeader,
+        _parent: &BlockHeader,
+        _chain_spec: &ChainSpec,
+    ) -> bool {
+        let is_link_broken = child.header.extra_data == "broken_link";
+        !is_link_broken
+    }
+
+    fn verify_slice(
+        &self,
+        _headers: &[BlockHeader],
+        _start_block_num: BlockNumber,
+        _max_timestamp: u64,
+        _chain_spec: &ChainSpec,
+    ) -> bool {
+        true
+    }
+}

--- a/src/downloader/headers/header_slices.rs
+++ b/src/downloader/headers/header_slices.rs
@@ -375,6 +375,10 @@ impl HeaderSlices {
     pub fn is_empty_at_final_position(&self) -> bool {
         (self.max_block_num() >= self.final_block_num) && self.slices.read().is_empty()
     }
+
+    pub fn all_in_status(&self, status: HeaderSliceStatus) -> bool {
+        self.count_slices_in_status(status) == self.slices.read().len()
+    }
 }
 
 pub fn align_block_num_to_slice_start(num: BlockNumber) -> BlockNumber {

--- a/src/downloader/headers/mod.rs
+++ b/src/downloader/headers/mod.rs
@@ -1,22 +1,24 @@
-mod average_delta_counter;
 pub mod downloader;
+pub mod header;
+pub mod header_slice_verifier;
+pub mod header_slice_verifier_mock;
+pub mod header_slices;
+
+mod average_delta_counter;
 mod downloader_forky;
 mod downloader_linear;
 mod downloader_preverified;
-pub mod header;
+mod downloader_stage_loop;
 mod header_slice_status_watch;
-pub mod header_slices;
 mod parallel;
-pub mod stage;
+mod preverified_hashes_config;
+mod stage;
 mod stage_stream;
 
-mod downloader_stage_loop;
 mod fetch_receive_stage;
 mod fetch_request_stage;
 mod fork_mode_stage;
-mod header_slice_verifier;
 mod penalize_stage;
-mod preverified_hashes_config;
 mod refetch_stage;
 mod refill_stage;
 mod retry_stage;

--- a/src/downloader/headers/refetch_stage.rs
+++ b/src/downloader/headers/refetch_stage.rs
@@ -1,4 +1,4 @@
-use crate::downloader::headers::{
+use super::{
     header_slice_status_watch::HeaderSliceStatusWatch,
     header_slices::{HeaderSliceStatus, HeaderSlices},
 };

--- a/src/downloader/headers/refill_stage.rs
+++ b/src/downloader/headers/refill_stage.rs
@@ -1,4 +1,4 @@
-use crate::downloader::headers::{
+use super::{
     header_slice_status_watch::HeaderSliceStatusWatch,
     header_slices::{HeaderSliceStatus, HeaderSlices},
 };
@@ -40,6 +40,11 @@ impl RefillStage {
     fn refill_pending(&self) {
         self.header_slices.remove(HeaderSliceStatus::Saved);
         self.header_slices.refill();
+    }
+
+    pub fn can_proceed_check(&self) -> impl Fn() -> bool {
+        let header_slices = self.header_slices.clone();
+        move || -> bool { !header_slices.is_empty_at_final_position() }
     }
 }
 

--- a/src/downloader/headers/retry_stage.rs
+++ b/src/downloader/headers/retry_stage.rs
@@ -1,4 +1,4 @@
-use crate::downloader::headers::{
+use super::{
     header_slice_status_watch::HeaderSliceStatusWatch,
     header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices},
 };

--- a/src/downloader/headers/verify_stage_forky_link.rs
+++ b/src/downloader/headers/verify_stage_forky_link.rs
@@ -1,5 +1,6 @@
 use super::{
     fork_mode_stage::ForkModeStage,
+    header_slice_verifier::HeaderSliceVerifier,
     header_slices::{HeaderSliceStatus, HeaderSlices},
     verify_stage_linear_link::VerifyStageLinearLink,
 };
@@ -11,6 +12,7 @@ use tracing::*;
 pub struct VerifyStageForkyLink {
     header_slices: Arc<HeaderSlices>,
     chain_config: ChainConfig,
+    verifier: Arc<Box<dyn HeaderSliceVerifier>>,
     start_block_num: BlockNumber,
     start_block_hash: ethereum_types::H256,
     mode: Mode,
@@ -25,12 +27,14 @@ impl VerifyStageForkyLink {
     pub fn new(
         header_slices: Arc<HeaderSlices>,
         chain_config: ChainConfig,
+        verifier: Arc<Box<dyn HeaderSliceVerifier>>,
         start_block_num: BlockNumber,
         start_block_hash: ethereum_types::H256,
     ) -> Self {
         let linear_mode_stage = VerifyStageLinearLink::new(
             header_slices.clone(),
             chain_config.clone(),
+            verifier.clone(),
             start_block_num,
             start_block_hash,
             HeaderSliceStatus::Fork,
@@ -39,6 +43,7 @@ impl VerifyStageForkyLink {
         Self {
             header_slices,
             chain_config,
+            verifier,
             start_block_num,
             start_block_hash,
             mode: Mode::Linear(Box::new(linear_mode_stage)),
@@ -80,6 +85,7 @@ impl VerifyStageForkyLink {
         VerifyStageLinearLink::new(
             self.header_slices.clone(),
             self.chain_config.clone(),
+            self.verifier.clone(),
             self.start_block_num,
             self.start_block_hash,
             HeaderSliceStatus::Fork,
@@ -91,7 +97,11 @@ impl VerifyStageForkyLink {
     }
 
     fn make_fork_mode_stage(&self) -> ForkModeStage {
-        ForkModeStage::new(self.header_slices.clone(), self.chain_config.clone())
+        ForkModeStage::new(
+            self.header_slices.clone(),
+            self.chain_config.clone(),
+            self.verifier.clone(),
+        )
     }
 
     fn switch_to_fork_mode(&mut self) {

--- a/src/downloader/headers/verify_stage_linear.rs
+++ b/src/downloader/headers/verify_stage_linear.rs
@@ -1,9 +1,10 @@
 use super::{
     header_slice_status_watch::HeaderSliceStatusWatch,
-    header_slice_verifier,
+    header_slice_verifier::HeaderSliceVerifier,
     header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices},
+    parallel::map_parallel,
 };
-use crate::{downloader::headers::parallel::map_parallel, sentry::chain_config::ChainConfig};
+use crate::sentry::chain_config::ChainConfig;
 use parking_lot::RwLock;
 use std::{ops::DerefMut, sync::Arc, time::SystemTime};
 use tracing::*;
@@ -12,14 +13,20 @@ use tracing::*;
 pub struct VerifyStageLinear {
     header_slices: Arc<HeaderSlices>,
     chain_config: ChainConfig,
+    verifier: Arc<Box<dyn HeaderSliceVerifier>>,
     pending_watch: HeaderSliceStatusWatch,
 }
 
 impl VerifyStageLinear {
-    pub fn new(header_slices: Arc<HeaderSlices>, chain_config: ChainConfig) -> Self {
+    pub fn new(
+        header_slices: Arc<HeaderSlices>,
+        chain_config: ChainConfig,
+        verifier: Arc<Box<dyn HeaderSliceVerifier>>,
+    ) -> Self {
         Self {
             header_slices: header_slices.clone(),
             chain_config,
+            verifier,
             pending_watch: HeaderSliceStatusWatch::new(
                 HeaderSliceStatus::Downloaded,
                 header_slices,
@@ -96,7 +103,7 @@ impl VerifyStageLinear {
             return false;
         };
 
-        header_slice_verifier::verify_slice(
+        self.verifier.verify_slice(
             headers,
             slice.start_block_num,
             Self::now_timestamp(),

--- a/src/downloader/headers/verify_stage_linear_link.rs
+++ b/src/downloader/headers/verify_stage_linear_link.rs
@@ -1,7 +1,8 @@
 use super::{
     header::BlockHeader,
     header_slice_status_watch::HeaderSliceStatusWatch,
-    header_slice_verifier, header_slices,
+    header_slice_verifier::HeaderSliceVerifier,
+    header_slices,
     header_slices::{HeaderSlice, HeaderSliceStatus, HeaderSlices},
 };
 use crate::{models::BlockNumber, sentry::chain_config::ChainConfig};
@@ -16,6 +17,7 @@ use tracing::*;
 pub struct VerifyStageLinearLink {
     header_slices: Arc<HeaderSlices>,
     chain_config: ChainConfig,
+    verifier: Arc<Box<dyn HeaderSliceVerifier>>,
     start_block_num: BlockNumber,
     start_block_hash: ethereum_types::H256,
     invalid_status: HeaderSliceStatus,
@@ -28,17 +30,21 @@ impl VerifyStageLinearLink {
     pub fn new(
         header_slices: Arc<HeaderSlices>,
         chain_config: ChainConfig,
+        verifier: Arc<Box<dyn HeaderSliceVerifier>>,
         start_block_num: BlockNumber,
         start_block_hash: ethereum_types::H256,
         invalid_status: HeaderSliceStatus,
     ) -> Self {
+        let last_verified_header = Self::find_last_verified_header(&header_slices);
+
         Self {
             header_slices: header_slices.clone(),
             chain_config,
+            verifier,
             start_block_num,
             start_block_hash,
             invalid_status,
-            last_verified_header: None,
+            last_verified_header,
             pending_watch: HeaderSliceStatusWatch::new(
                 HeaderSliceStatus::VerifiedInternally,
                 header_slices,
@@ -109,6 +115,27 @@ impl VerifyStageLinearLink {
         }
     }
 
+    fn find_last_verified_header(header_slices: &HeaderSlices) -> Option<BlockHeader> {
+        let mut last_verified_slice = Option::<Arc<RwLock<HeaderSlice>>>::None;
+
+        header_slices.try_fold((), |_, slice_lock| {
+            let slice = slice_lock.read();
+            match slice.status {
+                HeaderSliceStatus::Verified | HeaderSliceStatus::Saved => {
+                    last_verified_slice = Some(slice_lock.clone());
+                    ControlFlow::Continue(())
+                }
+                _ => ControlFlow::Break(()),
+            }
+        });
+
+        last_verified_slice.and_then(|slice_lock| {
+            let slice = slice_lock.read();
+            let headers = slice.headers.as_ref();
+            headers.and_then(|headers| -> Option<BlockHeader> { headers.last().cloned() })
+        })
+    }
+
     fn verify_pending_slice(&mut self, slice_lock: Arc<RwLock<HeaderSlice>>) -> bool {
         let slice = slice_lock.upgradable_read();
 
@@ -153,7 +180,8 @@ impl VerifyStageLinearLink {
         }
         let parent = parent.as_ref().unwrap();
 
-        header_slice_verifier::verify_link(child, parent, self.chain_config.chain_spec())
+        self.verifier
+            .verify_link(child, parent, self.chain_config.chain_spec())
     }
 }
 

--- a/src/downloader/mod.rs
+++ b/src/downloader/mod.rs
@@ -7,6 +7,8 @@ pub use headers::downloader::{
     DownloaderReport as HeaderDownloaderReport, DownloaderRunState as HeaderDownloaderRunState,
 };
 
+pub use headers::header_slice_verifier;
+
 #[cfg(test)]
 mod downloader_tests;
 

--- a/src/downloader/ui_system.rs
+++ b/src/downloader/ui_system.rs
@@ -1,4 +1,4 @@
-use crate::downloader::ui_view::UIView;
+use super::ui_view::UIView;
 use parking_lot::Mutex;
 use std::{sync::Arc, time::Duration};
 use tokio::{

--- a/src/stages/downloader.rs
+++ b/src/stages/downloader.rs
@@ -27,7 +27,15 @@ impl HeaderDownload {
         sentry: SentryClientReactorShared,
         sentry_status_provider: SentryStatusProvider,
     ) -> anyhow::Result<Self> {
-        let downloader = Downloader::new(chain_config, mem_limit, sentry, sentry_status_provider)?;
+        let verifier = crate::downloader::header_slice_verifier::make_ethash_verifier();
+
+        let downloader = Downloader::new(
+            chain_config,
+            verifier,
+            mem_limit,
+            sentry,
+            sentry_status_provider,
+        )?;
 
         let instance = Self {
             downloader,


### PR DESCRIPTION
Mode::Linear of VerifyStageForkyLink continues for as long as
it is possible to link slices to the canonical chain.

The test verifies that given a VerifiedInternally slice ("=")
it transitions to Saved ("+").
This has to be different from a slice with a broken link ("|="),
which must start Mode::Fork (in the fork_mode_start() test).

To distinguish the situations a HeaderSliceVerifierMock is used.
HeaderSliceVerifier is changed to a trait in stages
in order to substitute the verification logic for tests.