### PR TITLE
Downloader: fork mode chain continuation tests.

### DIFF
--- a/src/downloader/headers_downloader/downloader.rs
+++ b/src/downloader/headers_downloader/downloader.rs
@@ -53,10 +53,10 @@ impl Downloader {
         let verifier = Arc::new(verifier);
 
         let downloader_preverified = downloader_preverified::DownloaderPreverified::new(
-            chain_config.chain_name(),
+            verifier.preverified_hashes_config(&chain_config.chain_name())?,
             mem_limit,
             sentry.clone(),
-        )?;
+        );
 
         let downloader_linear = downloader_linear::DownloaderLinear::new(
             chain_config.clone(),

--- a/src/downloader/headers_downloader/downloader_linear.rs
+++ b/src/downloader/headers_downloader/downloader_linear.rs
@@ -138,10 +138,7 @@ impl DownloaderLinear {
         let save_stage = SaveStage::<RwTx>::new(header_slices.clone(), db_transaction);
         let refill_stage = RefillStage::new(header_slices.clone());
 
-        let fetch_receive_stage_can_proceed = fetch_receive_stage.can_proceed_check();
-        let refill_stage_can_proceed = refill_stage.can_proceed_check();
-        let can_proceed =
-            move |_| -> bool { fetch_receive_stage_can_proceed() && refill_stage_can_proceed() };
+        let refill_stage_is_over = refill_stage.is_over_check();
 
         let mut stages = DownloaderStageLoop::new(&header_slices);
         stages.insert(fetch_request_stage);
@@ -153,7 +150,7 @@ impl DownloaderLinear {
         stages.insert(save_stage);
         stages.insert(refill_stage);
 
-        stages.run(can_proceed).await;
+        stages.run(refill_stage_is_over).await;
 
         let report = DownloaderLinearReport {
             loaded_count: (header_slices.min_block_num().0 - start_block_num.0) as usize,

--- a/src/downloader/headers_downloader/stages/fetch_request_stage.rs
+++ b/src/downloader/headers_downloader/stages/fetch_request_stage.rs
@@ -129,11 +129,19 @@ impl FetchRequestStage {
         };
         sentry.try_send_message(Message::GetBlockHeaders(message), PeerFilter::Random(1))
     }
+
+    pub fn can_proceed_check(&self) -> impl Fn() -> bool {
+        let header_slices = self.header_slices.clone();
+        move || -> bool { header_slices.contains_status(HeaderSliceStatus::Empty) }
+    }
 }
 
 #[async_trait::async_trait]
 impl super::stage::Stage for FetchRequestStage {
     async fn execute(&mut self) -> anyhow::Result<()> {
         Self::execute(self).await
+    }
+    fn can_proceed_check(&self) -> Box<dyn Fn() -> bool + Send> {
+        Box::new(Self::can_proceed_check(self))
     }
 }

--- a/src/downloader/headers_downloader/stages/penalize_stage.rs
+++ b/src/downloader/headers_downloader/stages/penalize_stage.rs
@@ -80,11 +80,19 @@ impl PenalizeStage {
         }
         Ok(())
     }
+
+    pub fn can_proceed_check(&self) -> impl Fn() -> bool {
+        let header_slices = self.header_slices.clone();
+        move || -> bool { header_slices.contains_status(HeaderSliceStatus::Invalid) }
+    }
 }
 
 #[async_trait::async_trait]
 impl super::stage::Stage for PenalizeStage {
     async fn execute(&mut self) -> anyhow::Result<()> {
         Self::execute(self).await
+    }
+    fn can_proceed_check(&self) -> Box<dyn Fn() -> bool + Send> {
+        Box::new(Self::can_proceed_check(self))
     }
 }

--- a/src/downloader/headers_downloader/stages/refetch_stage.rs
+++ b/src/downloader/headers_downloader/stages/refetch_stage.rs
@@ -50,11 +50,19 @@ impl RefetchStage {
         });
         Ok(count)
     }
+
+    pub fn can_proceed_check(&self) -> impl Fn() -> bool {
+        let header_slices = self.header_slices.clone();
+        move || -> bool { header_slices.contains_status(HeaderSliceStatus::Refetch) }
+    }
 }
 
 #[async_trait::async_trait]
 impl super::stage::Stage for RefetchStage {
     async fn execute(&mut self) -> anyhow::Result<()> {
         Self::execute(self).await
+    }
+    fn can_proceed_check(&self) -> Box<dyn Fn() -> bool + Send> {
+        Box::new(Self::can_proceed_check(self))
     }
 }

--- a/src/downloader/headers_downloader/stages/refill_stage.rs
+++ b/src/downloader/headers_downloader/stages/refill_stage.rs
@@ -40,9 +40,14 @@ impl RefillStage {
         self.header_slices.refill();
     }
 
+    pub fn is_over_check(&self) -> impl Fn() -> bool {
+        let header_slices = self.header_slices.clone();
+        move || -> bool { header_slices.is_empty_at_final_position() }
+    }
+
     pub fn can_proceed_check(&self) -> impl Fn() -> bool {
         let header_slices = self.header_slices.clone();
-        move || -> bool { !header_slices.is_empty_at_final_position() }
+        move || -> bool { header_slices.contains_status(HeaderSliceStatus::Saved) }
     }
 }
 
@@ -50,5 +55,8 @@ impl RefillStage {
 impl super::stage::Stage for RefillStage {
     async fn execute(&mut self) -> anyhow::Result<()> {
         Self::execute(self).await
+    }
+    fn can_proceed_check(&self) -> Box<dyn Fn() -> bool + Send> {
+        Box::new(Self::can_proceed_check(self))
     }
 }

--- a/src/downloader/headers_downloader/stages/retry_stage.rs
+++ b/src/downloader/headers_downloader/stages/retry_stage.rs
@@ -75,11 +75,22 @@ impl RetryStage {
             _ => Duration::from_secs(30),
         }
     }
+
+    pub fn can_proceed_check(&self) -> impl Fn() -> bool {
+        // If FetchReceiveStage can't proceed when Waiting & is_over, RetryStage still can proceed.
+        // Returning header_slices.contains_status(HeaderSliceStatus::Waiting)
+        // means that some_stage_can_proceed() returns true in this case,
+        // but in tests we'd like to terminate without doing retries.
+        || -> bool { false }
+    }
 }
 
 #[async_trait::async_trait]
 impl super::stage::Stage for RetryStage {
     async fn execute(&mut self) -> anyhow::Result<()> {
         Self::execute(self).await
+    }
+    fn can_proceed_check(&self) -> Box<dyn Fn() -> bool + Send> {
+        Box::new(Self::can_proceed_check(self))
     }
 }

--- a/src/downloader/headers_downloader/stages/stage.rs
+++ b/src/downloader/headers_downloader/stages/stage.rs
@@ -3,4 +3,5 @@ use async_trait::async_trait;
 #[async_trait]
 pub trait Stage: Send {
     async fn execute(&mut self) -> anyhow::Result<()>;
+    fn can_proceed_check(&self) -> Box<dyn Fn() -> bool + Send>;
 }

--- a/src/downloader/headers_downloader/stages/top_block_estimate_stage.rs
+++ b/src/downloader/headers_downloader/stages/top_block_estimate_stage.rs
@@ -45,6 +45,12 @@ impl TopBlockEstimateStage {
     }
 
     pub async fn execute(&self) -> anyhow::Result<()> {
+        // when it is over - hang to avoid a live idle loop
+        // ideally stop calling this execute() in the make_stage_stream loop
+        if self.is_over.load(Ordering::SeqCst) {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+
         let mut message_stream = self.message_stream.try_lock()?;
         if message_stream.is_none() {
             let sentry = self.sentry.read().await;
@@ -125,11 +131,19 @@ impl TopBlockEstimateStage {
         let average_block_num = BlockNumber(block_nums.sum::<u64>() / (peer_blocks.len() as u64));
         Some(average_block_num)
     }
+
+    pub fn can_proceed_check(&self) -> impl Fn() -> bool {
+        let is_over = self.is_over.clone();
+        move || -> bool { !is_over.load(Ordering::SeqCst) }
+    }
 }
 
 #[async_trait::async_trait]
 impl super::stage::Stage for TopBlockEstimateStage {
     async fn execute(&mut self) -> anyhow::Result<()> {
         Self::execute(self).await
+    }
+    fn can_proceed_check(&self) -> Box<dyn Fn() -> bool + Send> {
+        Box::new(Self::can_proceed_check(self))
     }
 }

--- a/src/downloader/headers_downloader/stages/verify_stage_linear.rs
+++ b/src/downloader/headers_downloader/stages/verify_stage_linear.rs
@@ -109,11 +109,19 @@ impl VerifyStageLinear {
             self.chain_config.chain_spec(),
         )
     }
+
+    pub fn can_proceed_check(&self) -> impl Fn() -> bool {
+        let header_slices = self.header_slices.clone();
+        move || -> bool { header_slices.contains_status(HeaderSliceStatus::Downloaded) }
+    }
 }
 
 #[async_trait::async_trait]
 impl super::stage::Stage for VerifyStageLinear {
     async fn execute(&mut self) -> anyhow::Result<()> {
         Self::execute(self).await
+    }
+    fn can_proceed_check(&self) -> Box<dyn Fn() -> bool + Send> {
+        Box::new(Self::can_proceed_check(self))
     }
 }

--- a/src/downloader/headers_downloader/stages/verify_stage_linear_link.rs
+++ b/src/downloader/headers_downloader/stages/verify_stage_linear_link.rs
@@ -182,11 +182,19 @@ impl VerifyStageLinearLink {
         self.verifier
             .verify_link(child, parent, self.chain_config.chain_spec())
     }
+
+    pub fn can_proceed_check(&self) -> impl Fn() -> bool {
+        let header_slices = self.header_slices.clone();
+        move || -> bool { header_slices.contains_status(HeaderSliceStatus::VerifiedInternally) }
+    }
 }
 
 #[async_trait::async_trait]
 impl super::stage::Stage for VerifyStageLinearLink {
     async fn execute(&mut self) -> anyhow::Result<()> {
         Self::execute(self).await
+    }
+    fn can_proceed_check(&self) -> Box<dyn Fn() -> bool + Send> {
+        Box::new(Self::can_proceed_check(self))
     }
 }

--- a/src/downloader/headers_downloader/stages/verify_stage_preverified.rs
+++ b/src/downloader/headers_downloader/stages/verify_stage_preverified.rs
@@ -146,11 +146,19 @@ impl VerifyStagePreverified {
         let index = block_num / preverified_step_size;
         self.preverified_hashes.hashes.get(index as usize)
     }
+
+    pub fn can_proceed_check(&self) -> impl Fn() -> bool {
+        let header_slices = self.header_slices.clone();
+        move || -> bool { header_slices.contains_status(HeaderSliceStatus::Downloaded) }
+    }
 }
 
 #[async_trait::async_trait]
 impl super::stage::Stage for VerifyStagePreverified {
     async fn execute(&mut self) -> anyhow::Result<()> {
         Self::execute(self).await
+    }
+    fn can_proceed_check(&self) -> Box<dyn Fn() -> bool + Send> {
+        Box::new(Self::can_proceed_check(self))
     }
 }

--- a/src/downloader/headers_downloader/verification/header_slice_verifier.rs
+++ b/src/downloader/headers_downloader/verification/header_slice_verifier.rs
@@ -1,4 +1,6 @@
-use super::super::headers::header::BlockHeader;
+use super::{
+    super::headers::header::BlockHeader, preverified_hashes_config::PreverifiedHashesConfig,
+};
 use crate::{
     consensus::difficulty::{canonical_difficulty, BlockDifficultyBombData},
     models::{switch_is_active, BlockNumber, ChainSpec, SealVerificationParams, EMPTY_LIST_HASH},
@@ -20,6 +22,11 @@ pub trait HeaderSliceVerifier: Send + Sync + Debug {
         max_timestamp: u64,
         chain_spec: &ChainSpec,
     ) -> bool;
+
+    fn preverified_hashes_config(
+        &self,
+        chain_name: &str,
+    ) -> anyhow::Result<PreverifiedHashesConfig>;
 }
 
 pub fn make_ethash_verifier() -> Box<dyn HeaderSliceVerifier> {
@@ -55,6 +62,13 @@ impl HeaderSliceVerifier for EthashHeaderSliceVerifier {
             && verify_slice_timestamps(headers, max_timestamp)
             && verify_slice_difficulties(headers, chain_spec)
             && verify_slice_pow(headers)
+    }
+
+    fn preverified_hashes_config(
+        &self,
+        chain_name: &str,
+    ) -> anyhow::Result<PreverifiedHashesConfig> {
+        PreverifiedHashesConfig::new(chain_name)
     }
 }
 

--- a/src/downloader/headers_downloader/verification/header_slice_verifier_mock.rs
+++ b/src/downloader/headers_downloader/verification/header_slice_verifier_mock.rs
@@ -1,17 +1,39 @@
-use super::{super::headers::header::BlockHeader, header_slice_verifier::HeaderSliceVerifier};
+use super::{
+    super::headers::header::BlockHeader, header_slice_verifier::HeaderSliceVerifier,
+    preverified_hashes_config::PreverifiedHashesConfig,
+};
 use crate::models::{BlockNumber, ChainSpec};
-use bytes::Bytes;
+use std::fmt::{Debug, Formatter};
 
-#[derive(Debug)]
-pub struct HeaderSliceVerifierMock;
+pub struct HeaderSliceVerifierMock {
+    header_id: fn(header: &BlockHeader) -> u64,
+    broken_links: Vec<(u64, u64)>,
+}
+
+impl Debug for HeaderSliceVerifierMock {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HeaderSliceVerifierMock")
+            .field("broken_links", &self.broken_links)
+            .finish()
+    }
+}
 
 impl HeaderSliceVerifierMock {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(header_id: fn(header: &BlockHeader) -> u64) -> Self {
+        Self {
+            header_id,
+            broken_links: Vec::new(),
+        }
     }
 
-    pub fn mark_broken_link(&self, child: &mut BlockHeader) {
-        child.header.extra_data = Bytes::from("broken_link");
+    pub fn mark_broken_link(&mut self, child: &mut BlockHeader, parent: &mut BlockHeader) {
+        let child_id = (self.header_id)(child);
+        let parent_id = (self.header_id)(parent);
+
+        assert_ne!(child_id, 0);
+        assert_ne!(parent_id, 0);
+
+        self.broken_links.push((child_id, parent_id));
     }
 }
 
@@ -19,10 +41,12 @@ impl HeaderSliceVerifier for HeaderSliceVerifierMock {
     fn verify_link(
         &self,
         child: &BlockHeader,
-        _parent: &BlockHeader,
+        parent: &BlockHeader,
         _chain_spec: &ChainSpec,
     ) -> bool {
-        let is_link_broken = child.header.extra_data == "broken_link";
+        let child_id = (self.header_id)(child);
+        let parent_id = (self.header_id)(parent);
+        let is_link_broken = self.broken_links.contains(&(child_id, parent_id));
         !is_link_broken
     }
 
@@ -34,5 +58,12 @@ impl HeaderSliceVerifier for HeaderSliceVerifierMock {
         _chain_spec: &ChainSpec,
     ) -> bool {
         true
+    }
+
+    fn preverified_hashes_config(
+        &self,
+        _chain_name: &str,
+    ) -> anyhow::Result<PreverifiedHashesConfig> {
+        Ok(PreverifiedHashesConfig::empty())
     }
 }

--- a/src/downloader/headers_downloader/verification/preverified_hashes_config.rs
+++ b/src/downloader/headers_downloader/verification/preverified_hashes_config.rs
@@ -28,9 +28,17 @@ impl PreverifiedHashesConfig {
             _ => anyhow::bail!("unsupported chain"),
         };
         let config: PreverifiedHashesConfigUnprefixedHex = toml::from_str(config_text)?;
-        Ok(PreverifiedHashesConfig {
+        Ok(Self {
             hashes: config.hashes.iter().map(|hash| hash.0).collect(),
         })
+    }
+
+    pub fn empty() -> Self {
+        Self { hashes: Vec::new() }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.hashes.is_empty()
     }
 }
 


### PR DESCRIPTION
Tests to verify that in fork mode:
* extending the fork chain down is possible
* extending the canonical chain up is possible

Changes:
* preverified_hashes_config can be empty (for tests) to effectively skip DownloaderPreverified phase
* can_proceed_check is generalized for tests: the test is run for as long as any stage can make progress
	when SentryClientMock is drained, FetchReceiveStage is gonna stop making progress,
	but other stages still can, so that Downloaded status can proceed to Verified/Saved.
	Without this change the test was ended prematurely.
* implemented parse_sentry description and related SentryClientMock logic:
	when a request comes in for a known block - return that block, and remove from the list
	when the known blocks list is empty - end the stream
* HeaderGenerator: each slice generated in a test gets a unique ID in extra_data
	without this, the hashes of unrelated blocks were matching, and the fork connection was triggered
	those IDs are also used to mark broken links, otherwise a refetched header was also broken,
	because its parent was not taken into account.
* discard_fork logic simplified to only go until the fork_range.end
	leaving a potential Refetch canonical slice is not dangerous

Fixes:
* canonical continuation was not found, because find_by_block_num was not taking fork_headers into account
	fixed by introducint fork_block_num_range
* in tests when FetchReceiveStage is over - hang to avoid a live idle loop
* SentryClientMock: treat empty filter_ids as subscribe to all
* deadlocks were possible if calling header_slices.find after taking a write lock on a slice
	fixed by reshuffling the code to take the write lock as late as possible
* switch_to_fork discard: get the slice.len() before clearing it (or else it becomes 0)
* discard_fork: use slice.fork_len() instead of len() before clearing the fork_headers