### PR TITLE
Downloader: refactoring to separate fork header_slices.

### DIFF
--- a/src/downloader/headers_downloader/downloader.rs
+++ b/src/downloader/headers_downloader/downloader.rs
@@ -32,6 +32,7 @@ pub struct DownloaderReport {
 pub struct DownloaderRunState {
     pub estimated_top_block_num: Option<BlockNumber>,
     pub forky_header_slices: Option<Arc<HeaderSlices>>,
+    pub forky_fork_header_slices: Option<Arc<HeaderSlices>>,
 }
 
 impl Debug for DownloaderRunState {
@@ -39,6 +40,10 @@ impl Debug for DownloaderRunState {
         f.debug_struct("DownloaderRunState")
             .field("estimated_top_block_num", &self.estimated_top_block_num)
             .field("forky_header_slices", &self.forky_header_slices.is_some())
+            .field(
+                "forky_fork_header_slices",
+                &self.forky_fork_header_slices.is_some(),
+            )
             .finish()
     }
 }
@@ -168,6 +173,9 @@ impl Downloader {
                 previous_run_state
                     .as_ref()
                     .and_then(|state| state.forky_header_slices.clone()),
+                previous_run_state
+                    .as_ref()
+                    .and_then(|state| state.forky_fork_header_slices.clone()),
                 ui_system,
             )
             .await?;
@@ -179,6 +187,7 @@ impl Downloader {
             run_state: DownloaderRunState {
                 estimated_top_block_num: Some(linear_report.estimated_top_block_num),
                 forky_header_slices: forky_report.header_slices,
+                forky_fork_header_slices: forky_report.fork_header_slices,
             },
         };
 

--- a/src/downloader/headers_downloader/downloader_linear.rs
+++ b/src/downloader/headers_downloader/downloader_linear.rs
@@ -135,12 +135,17 @@ impl DownloaderLinear {
             HeaderSliceStatus::Invalid,
         );
         let penalize_stage = PenalizeStage::new(header_slices.clone(), sentry.clone());
-        let save_stage = SaveStage::<RwTx>::new(header_slices.clone(), db_transaction);
+        let save_stage = SaveStage::<RwTx>::new(
+            header_slices.clone(),
+            db_transaction,
+            save_stage::SaveOrder::Monotonic,
+            true,
+        );
         let refill_stage = RefillStage::new(header_slices.clone());
 
         let refill_stage_is_over = refill_stage.is_over_check();
 
-        let mut stages = DownloaderStageLoop::new(&header_slices);
+        let mut stages = DownloaderStageLoop::new(&header_slices, None);
         stages.insert(fetch_request_stage);
         stages.insert(fetch_receive_stage);
         stages.insert(retry_stage);

--- a/src/downloader/headers_downloader/downloader_preverified.rs
+++ b/src/downloader/headers_downloader/downloader_preverified.rs
@@ -97,7 +97,12 @@ impl DownloaderPreverified {
             self.preverified_hashes_config.clone(),
         );
         let penalize_stage = PenalizeStage::new(header_slices.clone(), sentry.clone());
-        let save_stage = SaveStage::<RwTx>::new(header_slices.clone(), db_transaction);
+        let save_stage = SaveStage::<RwTx>::new(
+            header_slices.clone(),
+            db_transaction,
+            save_stage::SaveOrder::Monotonic,
+            true,
+        );
         let refill_stage = RefillStage::new(header_slices.clone());
         let top_block_estimate_stage = TopBlockEstimateStage::new(sentry.clone());
 
@@ -106,7 +111,7 @@ impl DownloaderPreverified {
         let estimated_top_block_num_provider =
             top_block_estimate_stage.estimated_top_block_num_provider();
 
-        let mut stages = DownloaderStageLoop::new(&header_slices);
+        let mut stages = DownloaderStageLoop::new(&header_slices, None);
         stages.insert(fetch_request_stage);
         stages.insert(fetch_receive_stage);
         stages.insert(retry_stage);

--- a/src/downloader/headers_downloader/stages/fork_mode_stage.rs
+++ b/src/downloader/headers_downloader/stages/fork_mode_stage.rs
@@ -1,6 +1,7 @@
 use super::{
     headers::{
-        header::BlockHeader, header_slice_status_watch::HeaderSliceStatusWatch, header_slices,
+        header_slice_status_watch::{HeaderSliceStatusWatch, HeaderSliceStatusWatchSelector},
+        header_slices,
         header_slices::*,
     },
     verification::header_slice_verifier::HeaderSliceVerifier,
@@ -16,145 +17,205 @@ use tracing::*;
 
 pub struct ForkModeStage {
     header_slices: Arc<HeaderSlices>,
+    fork_header_slices: Arc<HeaderSlices>,
     chain_config: ChainConfig,
     verifier: Arc<Box<dyn HeaderSliceVerifier>>,
     canonical_range: Range<BlockNumber>,
     fork_range: Range<BlockNumber>,
-    pending_watch: HeaderSliceStatusWatch,
+    pending_watch: HeaderSliceStatusWatchSelector,
     remaining_count: usize,
+    fork_remaining_count: usize,
 }
 
 impl ForkModeStage {
     pub fn new(
         header_slices: Arc<HeaderSlices>,
+        fork_header_slices: Arc<HeaderSlices>,
         chain_config: ChainConfig,
         verifier: Arc<Box<dyn HeaderSliceVerifier>>,
     ) -> Self {
-        let Some(fork_slice_lock) = header_slices.find_by_status(HeaderSliceStatus::Fork) else {
-            panic!("invalid state: initial fork slice not found");
-        };
-
         let canonical_range = Self::find_canonical_range(&header_slices);
+        let fork_range = Self::find_fork_range(&fork_header_slices);
+
+        let pending_watch = HeaderSliceStatusWatchSelector::new(
+            "ForkModeStage",
+            HeaderSliceStatusWatch::new(
+                HeaderSliceStatus::VerifiedInternally,
+                header_slices.clone(),
+                "ForkModeStage",
+            ),
+            HeaderSliceStatusWatch::new(
+                HeaderSliceStatus::VerifiedInternally,
+                fork_header_slices.clone(),
+                "ForkModeStage",
+            ),
+        );
 
         Self {
-            header_slices: header_slices.clone(),
+            header_slices,
+            fork_header_slices,
             chain_config,
             verifier,
             canonical_range,
-            fork_range: fork_slice_lock.read().block_num_range(),
-            pending_watch: HeaderSliceStatusWatch::new(
-                HeaderSliceStatus::VerifiedInternally,
-                header_slices,
-                "ForkModeStage",
-            ),
+            fork_range,
+            pending_watch,
             remaining_count: 0,
+            fork_remaining_count: 0,
         }
     }
 
     pub async fn execute(&mut self) -> anyhow::Result<()> {
-        self.pending_watch.wait_while(self.remaining_count).await?;
+        self.pending_watch
+            .wait_while_all((self.remaining_count, self.fork_remaining_count))
+            .await?;
+        let (pending_count, fork_pending_count) = self.pending_watch.pending_counts();
 
-        self.process_pending()?;
+        debug!(
+            "ForkModeStage: processing {} slices and {} fork slices",
+            pending_count, fork_pending_count
+        );
+        let (updated_count, fork_updated_count) =
+            self.process_pending(pending_count, fork_pending_count)?;
 
-        self.remaining_count = self.pending_watch.pending_count();
+        self.remaining_count = pending_count - updated_count;
+        self.fork_remaining_count = fork_pending_count - fork_updated_count;
         Ok(())
     }
 
     // initial setup: start refetching on both ends
-    pub fn setup(&mut self) {
-        let Some(canonical_continuation_slice_lock) = self.find_canonical_continuation_slice() else { return };
-        let Some(fork_continuation_slice_lock) = self.find_fork_continuation_slice() else { return };
+    pub fn setup(&mut self) -> anyhow::Result<()> {
+        let Some(canonical_continuation_slice_lock) = self.find_canonical_continuation_slice() else {
+            return Err(anyhow::format_err!("ForkModeStage.setup: initial fork slice not found"));
+        };
 
-        let canonical_continuation_slice = canonical_continuation_slice_lock.upgradable_read();
-        let fork_continuation_slice = fork_continuation_slice_lock.upgradable_read();
-
-        if (self.fork_range.start == self.canonical_range.end)
-            && (canonical_continuation_slice.status == HeaderSliceStatus::Fork)
-            && (Self::is_canonical_slice_status(fork_continuation_slice.status))
-        {
-            let mut canonical_continuation_slice_mut =
-                RwLockUpgradableReadGuard::upgrade(canonical_continuation_slice);
-            let mut fork_continuation_slice_mut =
-                RwLockUpgradableReadGuard::upgrade(fork_continuation_slice);
-            self.refetch_slice(canonical_continuation_slice_mut.deref_mut());
-            self.refetch_slice(fork_continuation_slice_mut.deref_mut());
+        let mut canonical_continuation_slice = canonical_continuation_slice_lock.write();
+        if canonical_continuation_slice.status != HeaderSliceStatus::Fork {
+            return Err(anyhow::format_err!(
+                "ForkModeStage.setup: initial fork slice invalid status"
+            ));
         }
+
+        let fork_start = canonical_continuation_slice.start_block_num;
+        let fork_initial_slice_headers = canonical_continuation_slice.headers.take();
+        let fork_initial_slice_peer = canonical_continuation_slice.from_peer_id;
+        self.refetch_canonical_slice(canonical_continuation_slice.deref_mut());
+
+        let fork_initial_slice = HeaderSlice {
+            start_block_num: fork_start,
+            status: HeaderSliceStatus::Verified,
+            headers: fork_initial_slice_headers,
+            from_peer_id: fork_initial_slice_peer,
+            ..Default::default()
+        };
+        let fork_range = fork_initial_slice.block_num_range();
+
+        self.fork_header_slices
+            .reset_to_single_slice(fork_initial_slice);
+        self.fork_range = fork_range;
+        self.fork_header_slices.prepend_slice()?;
+        Ok(())
     }
 
-    fn process_pending(&mut self) -> anyhow::Result<()> {
-        let Some(canonical_continuation_slice_lock) = self.find_canonical_continuation_slice() else { return Ok(()) };
-        let Some(fork_continuation_slice_lock) = self.find_fork_continuation_slice() else { return Ok(()) };
-
+    fn process_pending(
+        &mut self,
+        pending_count: usize,
+        fork_pending_count: usize,
+    ) -> anyhow::Result<(usize, usize)> {
         // try to extend the chains
         let mut did_extend_canonical = false;
         let mut did_extend_fork = false;
 
-        if canonical_continuation_slice_lock.read().status == HeaderSliceStatus::VerifiedInternally
+        let mut updated_count = 0;
+        let mut fork_updated_count = 0;
+
+        // try to extend the canonical chain
+        let canonical_continuation_slice_lock_opt = self.find_canonical_continuation_slice();
+        let canonical_continuation_slice_status = canonical_continuation_slice_lock_opt
+            .as_ref()
+            .map(|slice| slice.read().status);
+        if (canonical_continuation_slice_status == Some(HeaderSliceStatus::VerifiedInternally))
+            && (updated_count < pending_count)
         {
-            let continuation_slice_lock = canonical_continuation_slice_lock;
+            let continuation_slice_lock = canonical_continuation_slice_lock_opt.unwrap();
             did_extend_canonical = self.try_extend_canonical(continuation_slice_lock.clone());
             if !did_extend_canonical {
-                self.refetch_slice(continuation_slice_lock.write().deref_mut());
+                self.refetch_canonical_slice(continuation_slice_lock.write().deref_mut());
             }
+            updated_count += 1;
         }
 
-        if fork_continuation_slice_lock.read().status == HeaderSliceStatus::VerifiedInternally {
-            let continuation_slice_lock = fork_continuation_slice_lock;
+        // try to extend the fork chain
+        let fork_continuation_slice_lock_opt = self.find_fork_continuation_slice();
+        let fork_continuation_slice_status = fork_continuation_slice_lock_opt
+            .as_ref()
+            .map(|slice| slice.read().status);
+        if (fork_continuation_slice_status == Some(HeaderSliceStatus::VerifiedInternally))
+            && (fork_updated_count < fork_pending_count)
+        {
+            let continuation_slice_lock = fork_continuation_slice_lock_opt.unwrap();
             did_extend_fork = self.try_extend_fork(continuation_slice_lock.clone());
             if !did_extend_fork {
-                self.refetch_slice(continuation_slice_lock.write().deref_mut());
+                self.refetch_fork_slice(continuation_slice_lock.write().deref_mut());
             }
+            fork_updated_count += 1;
         }
 
         // check termination conditions
         if did_extend_fork {
-            let fork_first_slice_lock = self.find_fork_first_slice().unwrap();
-            let connection_block_num_opt =
-                Self::find_fork_connection_block_num(&fork_first_slice_lock.read());
+            let connection_block_num_opt = self.find_fork_connection_block_num();
             if let Some(connection_block_num) = connection_block_num_opt {
                 if self.fork_range_difficulty(connection_block_num)
                     > self.canonical_range_difficulty(connection_block_num)
                 {
-                    self.switch_to_fork(connection_block_num);
+                    self.switch_to_fork();
                 } else {
                     self.discard_fork();
                 }
-                return Ok(());
+                return Ok((updated_count, fork_updated_count));
             }
 
             if self.fork_range.start == self.canonical_range.start {
                 self.discard_fork();
-                return Ok(());
+                return Ok((updated_count, fork_updated_count));
             }
         }
 
-        // if not terminated, continue refetching
+        // if not terminated, continue loading adjacent slices further
 
+        // continue prolonging the canonical chain
         if did_extend_canonical {
             if let Some(continuation_slice_lock) = self.find_canonical_continuation_slice() {
-                self.refetch_slice(continuation_slice_lock.write().deref_mut());
+                let old_status = continuation_slice_lock.read().status;
+                self.refetch_canonical_slice(continuation_slice_lock.write().deref_mut());
+
+                if (old_status == HeaderSliceStatus::VerifiedInternally)
+                    && (updated_count < pending_count)
+                {
+                    updated_count += 1;
+                }
             }
         }
 
+        // continue prolonging the fork chain
         if did_extend_fork {
-            if let Some(continuation_slice_lock) = self.find_fork_continuation_slice() {
-                self.refetch_slice(continuation_slice_lock.write().deref_mut());
-            }
+            self.fork_header_slices.prepend_slice()?;
         }
 
-        Ok(())
+        Ok((updated_count, fork_updated_count))
     }
 
     pub fn is_done(&self) -> bool {
-        self.fork_range.is_empty()
+        self.fork_header_slices.is_empty()
     }
 
-    fn refetch_slice(&self, slice: &mut HeaderSlice) {
-        if slice.fork_headers.is_none() {
-            slice.fork_status = slice.status;
-            slice.fork_headers = slice.headers.take();
-        }
+    fn refetch_canonical_slice(&self, slice: &mut HeaderSlice) {
         self.header_slices
+            .set_slice_status(slice, HeaderSliceStatus::Refetch);
+        slice.headers = None;
+    }
+
+    fn refetch_fork_slice(&self, slice: &mut HeaderSlice) {
+        self.fork_header_slices
             .set_slice_status(slice, HeaderSliceStatus::Refetch);
         slice.headers = None;
     }
@@ -164,7 +225,7 @@ impl ForkModeStage {
         let end_slice = end_slice_lock.read();
         let continuation_slice = continuation_slice_lock.upgradable_read();
 
-        if self.verify_canonical_slices_link(&continuation_slice, &end_slice) {
+        if self.verify_slices_link(&continuation_slice, &end_slice) {
             let mut continuation_slice_mut = RwLockUpgradableReadGuard::upgrade(continuation_slice);
             let continuation_slice = continuation_slice_mut.deref_mut();
 
@@ -180,15 +241,15 @@ impl ForkModeStage {
 
     fn try_extend_fork(&mut self, continuation_slice_lock: Arc<RwLock<HeaderSlice>>) -> bool {
         let Some(end_slice_lock) = self.find_fork_first_slice() else { return false };
-        let end_slice = end_slice_lock.read();
         let continuation_slice = continuation_slice_lock.upgradable_read();
+        let end_slice = end_slice_lock.read();
 
-        if self.verify_fork_slices_link(&end_slice, &continuation_slice) {
+        if self.verify_slices_link(&end_slice, &continuation_slice) {
             let mut continuation_slice_mut = RwLockUpgradableReadGuard::upgrade(continuation_slice);
             let continuation_slice = continuation_slice_mut.deref_mut();
 
-            self.header_slices
-                .set_slice_status(continuation_slice, HeaderSliceStatus::Fork);
+            self.fork_header_slices
+                .set_slice_status(continuation_slice, HeaderSliceStatus::Verified);
             continuation_slice.refetch_attempt = 0;
             self.fork_range.start = continuation_slice.block_num_range().start;
             true
@@ -197,67 +258,28 @@ impl ForkModeStage {
         }
     }
 
-    fn verify_fork_slices_link(
-        &self,
-        child_slice: &HeaderSlice,
-        parent_slice: &HeaderSlice,
-    ) -> bool {
-        let child_headers_opt = if child_slice.status == HeaderSliceStatus::Fork {
-            child_slice.headers.as_ref()
-        } else if child_slice.fork_status == HeaderSliceStatus::Fork {
-            child_slice.fork_headers.as_ref()
-        } else {
-            None
-        };
-
-        let Some(child_headers) = child_headers_opt else { return false; };
+    fn verify_slices_link(&self, child_slice: &HeaderSlice, parent_slice: &HeaderSlice) -> bool {
+        let Some(child_headers) = &child_slice.headers else { return false; };
         let Some(parent_headers) = &parent_slice.headers else { return false; };
 
-        self.verify_headers_link(child_headers, parent_headers)
-    }
+        let Some(child) = child_headers.first() else { return false };
+        let Some(parent) = parent_headers.last() else { return false };
 
-    fn verify_canonical_slices_link(
-        &self,
-        child_slice: &HeaderSlice,
-        parent_slice: &HeaderSlice,
-    ) -> bool {
-        let parent_headers_opt = if Self::is_canonical_slice_status(parent_slice.status) {
-            parent_slice.headers.as_ref()
-        } else if Self::is_canonical_slice_status(parent_slice.fork_status) {
-            parent_slice.fork_headers.as_ref()
-        } else {
-            None
-        };
-
-        let Some(child_headers) = &child_slice.headers else { return false; };
-        let Some(parent_headers) = &parent_headers_opt else { return false; };
-
-        self.verify_headers_link(child_headers, parent_headers)
-    }
-
-    fn is_canonical_slice_status(status: HeaderSliceStatus) -> bool {
-        (status == HeaderSliceStatus::Verified) || (status == HeaderSliceStatus::Saved)
-    }
-
-    fn is_fork_slice_status(status: HeaderSliceStatus) -> bool {
-        status == HeaderSliceStatus::Fork
-    }
-
-    fn verify_headers_link(
-        &self,
-        child_headers: &[BlockHeader],
-        parent_headers: &[BlockHeader],
-    ) -> bool {
-        let child = child_headers.first().unwrap();
-        let parent = parent_headers.last().unwrap();
         self.verifier
             .verify_link(child, parent, self.chain_config.chain_spec())
     }
 
-    fn find_fork_connection_block_num(fork_slice: &HeaderSlice) -> Option<BlockNumber> {
-        let Some(headers) = &fork_slice.headers else { return None; };
-        let Some(fork_headers) = &fork_slice.fork_headers else { return None; };
-        headers
+    fn find_fork_connection_block_num(&self) -> Option<BlockNumber> {
+        let Some(fork_slice_lock) = self.find_fork_first_slice() else { return None };
+        let fork_slice = fork_slice_lock.read();
+
+        let Some(canonical_slice_lock) = self.header_slices.find_by_start_block_num(fork_slice.start_block_num) else { return None };
+        let canonical_slice = canonical_slice_lock.read();
+
+        let Some(canonical_headers) = &canonical_slice.headers else { return None; };
+        let Some(fork_headers) = &fork_slice.headers else { return None; };
+
+        canonical_headers
             .iter()
             .zip(fork_headers.iter())
             .rfind(|(header, fork_header)| header.hash() == fork_header.hash())
@@ -275,12 +297,33 @@ impl ForkModeStage {
                 range.end = slice.start_block_num;
             }
 
-            match slice.status {
-                HeaderSliceStatus::Verified | HeaderSliceStatus::Saved => {
-                    range.end = slice.block_num_range().end;
-                    ControlFlow::Continue(())
-                }
-                _ => ControlFlow::Break(()),
+            if Self::is_canonical_slice_status(slice.status) {
+                range.end = slice.block_num_range().end;
+                ControlFlow::Continue(())
+            } else {
+                ControlFlow::Break(())
+            }
+        });
+
+        range
+    }
+
+    fn find_fork_range(header_slices: &HeaderSlices) -> Range<BlockNumber> {
+        let mut range = BlockNumber(0)..BlockNumber(0);
+
+        header_slices.try_rfold((), |_, slice_lock| {
+            let slice = slice_lock.read();
+
+            if (range.start.0 == 0) && range.is_empty() {
+                range.end = slice.block_num_range().end;
+                range.start = range.end;
+            }
+
+            if Self::is_canonical_slice_status(slice.status) {
+                range.start = slice.start_block_num;
+                ControlFlow::Continue(())
+            } else {
+                ControlFlow::Break(())
             }
         });
 
@@ -289,116 +332,82 @@ impl ForkModeStage {
 
     /// Calculate total difficulty of the canonical chain starting after the connection block.
     fn canonical_range_difficulty(&self, connection_block_num: BlockNumber) -> U256 {
-        self.range_difficulty(
+        Self::range_difficulty(
+            self.header_slices.clone(),
             self.canonical_range.clone(),
             connection_block_num,
-            Self::is_canonical_slice_status,
         )
     }
 
     /// Calculate total difficulty of the fork starting after the connection block.
     fn fork_range_difficulty(&self, connection_block_num: BlockNumber) -> U256 {
-        self.range_difficulty(
+        Self::range_difficulty(
+            self.fork_header_slices.clone(),
             self.fork_range.clone(),
             connection_block_num,
-            Self::is_fork_slice_status,
         )
     }
 
     /// Calculate total difficulty of the range starting after the connection block.
     fn range_difficulty(
-        &self,
+        header_slices: Arc<HeaderSlices>,
         range: Range<BlockNumber>,
         connection_block_num: BlockNumber,
-        slice_status_predicate: impl Fn(HeaderSliceStatus) -> bool,
     ) -> U256 {
         let mut difficulty: U256 = U256::zero();
+        let mut num = BlockNumber(connection_block_num.0 + 1);
 
-        for num in range {
-            if num <= connection_block_num {
-                continue;
-            }
-
-            let Some(slice_lock) = self.header_slices.find_by_block_num(num) else {
+        while range.contains(&num) {
+            let Some(slice_lock) = header_slices.find_by_block_num(num) else {
                 warn!("range_difficulty invalid state: slice not found");
                 break;
             };
             let slice = slice_lock.read();
 
-            let slice_headers_opt = if slice_status_predicate(slice.status) {
-                slice.headers.as_ref()
-            } else if slice_status_predicate(slice.fork_status) {
-                slice.fork_headers.as_ref()
-            } else {
-                None
-            };
-            let Some(slice_headers) = slice_headers_opt else {
+            if !Self::is_canonical_slice_status(slice.status) {
+                warn!("range_difficulty invalid state: bad status");
+                break;
+            }
+
+            let Some(slice_headers) = slice.headers.as_ref() else {
                 warn!("range_difficulty invalid state: slice headers not present");
                 break;
             };
 
-            let index = (num.0 - slice.start_block_num.0) as usize;
-            let header = &slice_headers[index];
-            difficulty += header.difficulty()
+            let mut index = (num.0 - slice.start_block_num.0) as usize;
+
+            while (index < slice_headers.len()) && range.contains(&num) {
+                let header = &slice_headers[index];
+                difficulty += header.difficulty();
+
+                index += 1;
+                num = BlockNumber(num.0 + 1);
+            }
         }
 
         difficulty
     }
 
-    fn switch_to_fork(&mut self, connection_block_num: BlockNumber) {
-        // stop refetching
-        while let Some(slice_lock) = self
-            .header_slices
-            .find_by_status(HeaderSliceStatus::Refetch)
-        {
-            let mut slice = slice_lock.write();
-            if slice.status == HeaderSliceStatus::Refetch {
-                let new_status = slice.fork_status;
-                self.header_slices
-                    .set_slice_status(slice.deref_mut(), new_status);
-                slice.headers = slice.fork_headers.take();
-                slice.fork_status = HeaderSliceStatus::Empty;
-                slice.refetch_attempt = 0;
-            }
-        }
-
-        // swap fork headers before the connection point to existing canonical
-        // (although in practice they should also be equal)
-        {
-            let fork_first_slice_lock = self.find_fork_first_slice().unwrap();
-            let mut fork_first_slice = fork_first_slice_lock.write();
-            let len = (connection_block_num.0 - fork_first_slice.start_block_num.0) as usize;
-            let canonical_headers = fork_first_slice.fork_headers.take().unwrap();
-            let fork_headers = fork_first_slice.headers.as_mut().unwrap();
-            let fork_headers_part = &mut fork_headers[0..len];
-            fork_headers_part.clone_from_slice(&canonical_headers[0..len]);
-        }
-
+    fn switch_to_fork(&mut self) {
         // promote the fork chain
         let mut num = self.fork_range.start;
         while num < self.fork_range.end {
             let slice_lock = self.header_slices.find_by_start_block_num(num).unwrap();
+            let fork_slice_lock = self
+                .fork_header_slices
+                .find_by_start_block_num(num)
+                .unwrap();
+
             let mut slice_mut = slice_lock.write();
             let slice = slice_mut.deref_mut();
 
-            // promote the status
-            if slice.status == HeaderSliceStatus::Fork {
-                self.header_slices
-                    .set_slice_status(slice, HeaderSliceStatus::Verified);
-            } else if slice.fork_status == HeaderSliceStatus::Fork {
-                self.header_slices
-                    .set_slice_status(slice, HeaderSliceStatus::Verified);
-                slice.headers = slice.fork_headers.take();
-            } else {
-                panic!(
-                    "switch_to_fork invalid state: fork slice has an unexpected status {:?}/{:?}",
-                    slice.status, slice.fork_status
-                );
-            }
+            let mut fork_slice_mut = fork_slice_lock.write();
+            let fork_slice = fork_slice_mut.deref_mut();
 
-            // cleanup the fork data
-            slice.fork_status = HeaderSliceStatus::Empty;
-            slice.fork_headers = None;
+            // promote the status
+            self.header_slices
+                .set_slice_status(slice, fork_slice.status);
+            slice.headers = fork_slice.headers.take();
             slice.refetch_attempt = 0;
 
             num = BlockNumber(num.0 + slice.len() as u64);
@@ -421,13 +430,10 @@ impl ForkModeStage {
             let len = slice.len();
             assert!(len > 0, "a canonical chain slice must have headers");
 
+            // reset the status
             self.header_slices
                 .set_slice_status(slice, HeaderSliceStatus::Empty);
             slice.headers = None;
-
-            // cleanup the fork data
-            slice.fork_status = HeaderSliceStatus::Empty;
-            slice.fork_headers = None;
             slice.refetch_attempt = 0;
 
             num = BlockNumber(num.0 + len as u64);
@@ -435,57 +441,11 @@ impl ForkModeStage {
 
         // done
         self.canonical_range.end = self.fork_range.end;
-        self.fork_range.start = self.fork_range.end;
+        self.discard_fork();
     }
 
     fn discard_fork(&mut self) {
-        let mut num = self.fork_range.start;
-
-        // add a potential fork continuation slice to the range
-        if self.canonical_range.start < num {
-            num = align_block_num_to_slice_start(BlockNumber(num.0 - 1));
-        }
-
-        let last_fork_slice_start =
-            align_block_num_to_slice_start(BlockNumber(self.fork_range.end.0 - 1));
-
-        while num < last_fork_slice_start {
-            let slice_lock = self.header_slices.find_by_start_block_num(num).unwrap();
-            let mut slice_mut = slice_lock.write();
-            let slice = slice_mut.deref_mut();
-
-            // slices within the fork range before the last must have a canonical fork_status
-            // (including the fork continuation slice if any)
-            assert!(Self::is_canonical_slice_status(slice.fork_status));
-            let len = slice.fork_len();
-            assert!(len > 0, "a canonical chain slice must have headers");
-
-            // recover the backed up data
-            self.header_slices
-                .set_slice_status(slice, slice.fork_status);
-            slice.headers = slice.fork_headers.take();
-
-            // cleanup the fork data
-            slice.fork_status = HeaderSliceStatus::Empty;
-            slice.fork_headers = None;
-            slice.refetch_attempt = 0;
-
-            num = BlockNumber(num.0 + len as u64);
-        }
-
-        // the last fork slice has X/Y status (typically +/Y)
-        let last_fork_slice_lock = self
-            .header_slices
-            .find_by_start_block_num(last_fork_slice_start)
-            .unwrap();
-        let mut last_fork_slice = last_fork_slice_lock.write();
-
-        // cleanup the fork data
-        last_fork_slice.fork_status = HeaderSliceStatus::Empty;
-        last_fork_slice.fork_headers = None;
-        last_fork_slice.refetch_attempt = 0;
-
-        // done
+        self.fork_header_slices.clear();
         self.fork_range.start = self.fork_range.end;
     }
 
@@ -495,22 +455,39 @@ impl ForkModeStage {
     }
 
     fn find_fork_continuation_slice(&self) -> Option<Arc<RwLock<HeaderSlice>>> {
-        self.header_slices
-            .find_by_block_num(BlockNumber(self.fork_range.start.0 - 1))
+        let fork_start = self.fork_range.start.0;
+        if fork_start == 0 {
+            return None;
+        }
+        self.fork_header_slices
+            .find_by_block_num(BlockNumber(fork_start - 1))
     }
 
     fn find_canonical_last_slice(&self) -> Option<Arc<RwLock<HeaderSlice>>> {
+        let canonical_end = self.canonical_range.end.0;
+        if canonical_end == 0 {
+            return None;
+        }
         self.header_slices
-            .find_by_block_num(BlockNumber(self.canonical_range.end.0 - 1))
+            .find_by_block_num(BlockNumber(canonical_end - 1))
     }
 
     fn find_fork_first_slice(&self) -> Option<Arc<RwLock<HeaderSlice>>> {
-        self.header_slices.find_by_block_num(self.fork_range.start)
+        self.fork_header_slices
+            .find_by_block_num(self.fork_range.start)
+    }
+
+    fn is_canonical_slice_status(status: HeaderSliceStatus) -> bool {
+        (status == HeaderSliceStatus::Verified) || (status == HeaderSliceStatus::Saved)
     }
 
     pub fn can_proceed_check(&self) -> impl Fn() -> bool {
         let header_slices = self.header_slices.clone();
-        move || -> bool { header_slices.contains_status(HeaderSliceStatus::VerifiedInternally) }
+        let fork_header_slices = self.fork_header_slices.clone();
+        move || -> bool {
+            header_slices.contains_status(HeaderSliceStatus::VerifiedInternally)
+                || fork_header_slices.contains_status(HeaderSliceStatus::VerifiedInternally)
+        }
     }
 }
 

--- a/src/downloader/headers_downloader/stages/mod.rs
+++ b/src/downloader/headers_downloader/stages/mod.rs
@@ -1,3 +1,4 @@
+pub mod save_stage;
 pub mod stage;
 
 use super::{headers, verification};
@@ -9,7 +10,6 @@ mod penalize_stage;
 mod refetch_stage;
 mod refill_stage;
 mod retry_stage;
-mod save_stage;
 mod top_block_estimate_stage;
 mod verify_stage_forky_link;
 mod verify_stage_linear;

--- a/src/downloader/headers_downloader/stages/save_stage.rs
+++ b/src/downloader/headers_downloader/stages/save_stage.rs
@@ -18,25 +18,39 @@ use std::{
 };
 use tracing::*;
 
+pub enum SaveOrder {
+    Monotonic,
+    Random,
+}
+
 /// Saves slices into the database, and sets Saved status.
 pub struct SaveStage<'tx, RwTx> {
     header_slices: Arc<HeaderSlices>,
+    db_transaction: &'tx RwTx,
+    order: SaveOrder,
+    is_canonical_chain: bool,
     pending_watch: HeaderSliceStatusWatch,
     remaining_count: Arc<AtomicUsize>,
-    db_transaction: &'tx RwTx,
 }
 
 impl<'tx, 'db: 'tx, RwTx: MutableTransaction<'db>> SaveStage<'tx, RwTx> {
-    pub fn new(header_slices: Arc<HeaderSlices>, db_transaction: &'tx RwTx) -> Self {
+    pub fn new(
+        header_slices: Arc<HeaderSlices>,
+        db_transaction: &'tx RwTx,
+        order: SaveOrder,
+        is_canonical_chain: bool,
+    ) -> Self {
         Self {
             header_slices: header_slices.clone(),
+            db_transaction,
+            order,
+            is_canonical_chain,
             pending_watch: HeaderSliceStatusWatch::new(
                 HeaderSliceStatus::Verified,
                 header_slices,
                 "SaveStage",
             ),
             remaining_count: Arc::new(AtomicUsize::new(0)),
-            db_transaction,
         }
     }
 
@@ -52,7 +66,10 @@ impl<'tx, 'db: 'tx, RwTx: MutableTransaction<'db>> SaveStage<'tx, RwTx> {
         let pending_count = self.pending_watch.pending_count();
 
         debug!("SaveStage: saving {} slices", pending_count);
-        let saved_count = self.save_pending_monotonic(pending_count).await?;
+        let saved_count = match self.order {
+            SaveOrder::Monotonic => self.save_pending_monotonic(pending_count).await?,
+            SaveOrder::Random => self.save_pending_all(pending_count).await?,
+        };
         debug!("SaveStage: saved {} slices", saved_count);
 
         self.set_remaining_count(pending_count - saved_count);
@@ -111,13 +128,17 @@ impl<'tx, 'db: 'tx, RwTx: MutableTransaction<'db>> SaveStage<'tx, RwTx> {
         }
     }
 
-    // this is kept for performance comparison with save_pending_monotonic
-    async fn save_pending_all(&self, _pending_count: usize) -> anyhow::Result<usize> {
+    async fn save_pending_all(&self, pending_count: usize) -> anyhow::Result<usize> {
         let mut saved_count: usize = 0;
         while let Some(slice_lock) = self
             .header_slices
             .find_by_status(HeaderSliceStatus::Verified)
         {
+            // don't update more than asked
+            if saved_count >= pending_count {
+                break;
+            }
+
             self.save_slice(slice_lock).await?;
             saved_count += 1;
         }
@@ -159,23 +180,29 @@ impl<'tx, 'db: 'tx, RwTx: MutableTransaction<'db>> SaveStage<'tx, RwTx> {
         let block_num = header.number();
         let header_hash = header.hash();
         let header_key: HeaderKey = (block_num, header_hash);
-        let total_difficulty = header.difficulty();
 
         // saving a precomputed RLP representation
         tx.set(HeaderTableWithBytes, header_key, header.rlp_repr())
             .await?;
         tx.set(kv::tables::HeaderNumber, header_hash, block_num)
             .await?;
-        tx.set(kv::tables::CanonicalHeader, block_num, header_hash)
+
+        if self.is_canonical_chain {
+            tx.set(kv::tables::CanonicalHeader, block_num, header_hash)
+                .await?;
+            tx.set(kv::tables::LastHeader, Default::default(), header_hash)
+                .await?;
+
+            // TODO: fix - get the current value from db
+            let mut total_difficulty = ethereum_types::U256::zero();
+            total_difficulty += header.difficulty();
+            tx.set(
+                kv::tables::HeadersTotalDifficulty,
+                header_key,
+                total_difficulty,
+            )
             .await?;
-        tx.set(
-            kv::tables::HeadersTotalDifficulty,
-            header_key,
-            total_difficulty,
-        )
-        .await?;
-        tx.set(kv::tables::LastHeader, Default::default(), header_hash)
-            .await?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Create a separate fork_header_slices for managing the fork.
The fork_header_slices progress is driven by a second group of stages.
The link verification stage is common and handles linking of both
main header_slices and fork_header_slices.

* discard_fork simplified
* switch_to_fork simplified
* verify_slices_link simplified

Improved:
* possible to start VerifyStageForkyLink in fork mode
* remaining_count update made safe from race conditions
* optimized range_difficulty
* handle possible case of continuation_slice = None
* fork_header_slices save stage saves the fork headers for reuse (fast setup and switching)
* this unblocks monotonic canonical chain save in fork mode