### PR TITLE
Downloader: tests check IDs.

### DIFF
--- a/src/downloader/headers_downloader/verification/header_slice_verifier_mock.rs
+++ b/src/downloader/headers_downloader/verification/header_slice_verifier_mock.rs
@@ -7,33 +7,17 @@ use std::fmt::{Debug, Formatter};
 
 pub struct HeaderSliceVerifierMock {
     header_id: fn(header: &BlockHeader) -> u64,
-    broken_links: Vec<(u64, u64)>,
 }
 
 impl Debug for HeaderSliceVerifierMock {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("HeaderSliceVerifierMock")
-            .field("broken_links", &self.broken_links)
-            .finish()
+        f.debug_struct("HeaderSliceVerifierMock").finish()
     }
 }
 
 impl HeaderSliceVerifierMock {
     pub fn new(header_id: fn(header: &BlockHeader) -> u64) -> Self {
-        Self {
-            header_id,
-            broken_links: Vec::new(),
-        }
-    }
-
-    pub fn mark_broken_link(&mut self, child: &mut BlockHeader, parent: &mut BlockHeader) {
-        let child_id = (self.header_id)(child);
-        let parent_id = (self.header_id)(parent);
-
-        assert_ne!(child_id, 0);
-        assert_ne!(parent_id, 0);
-
-        self.broken_links.push((child_id, parent_id));
+        Self { header_id }
     }
 }
 
@@ -46,8 +30,7 @@ impl HeaderSliceVerifier for HeaderSliceVerifierMock {
     ) -> bool {
         let child_id = (self.header_id)(child);
         let parent_id = (self.header_id)(parent);
-        let is_link_broken = self.broken_links.contains(&(child_id, parent_id));
-        !is_link_broken
+        child_id == parent_id + 1
     }
 
     fn verify_slice(

--- a/src/sentry/sentry_client_mock.rs
+++ b/src/sentry/sentry_client_mock.rs
@@ -40,6 +40,13 @@ impl SentryClientMock {
         let start_block_num = first_header.number;
         self.block_headers.insert(start_block_num, headers);
     }
+
+    pub fn block_headers_mut(
+        &mut self,
+        start_block_num: BlockNumber,
+    ) -> Option<&mut Vec<BlockHeader>> {
+        self.block_headers.get_mut(&start_block_num)
+    }
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
Generate fixed IDs instead of sequential IDs for the test headers.

By default the IDs match the block numbers.
Custom IDs are denoted as 'a, 'b, 'c etc.
For each slice headers a range of IDs is assigned:
'a = [0..192], 'b = [192..384], 'c = [384..576] etc.

HeaderSliceVerifierMock logic is simplified:
verify_link succeeds if the blocks have sequential IDs.
For example, 'c can be linked to 'd, but not to 'f,
while 'e can be linked to 'f.

This obsoletes the "|=" notation,
adds more checks for block positions in result/forked
and prepares for more complicated test cases.