### PR TITLE
Downloader: test fork connection.

### DIFF
--- a/src/downloader/headers_downloader/stages/fork_mode_stage.rs
+++ b/src/downloader/headers_downloader/stages/fork_mode_stage.rs
@@ -164,9 +164,10 @@ impl ForkModeStage {
         if did_extend_fork {
             let connection_block_num_opt = self.find_fork_connection_block_num();
             if let Some(connection_block_num) = connection_block_num_opt {
-                if self.fork_range_difficulty(connection_block_num)
-                    > self.canonical_range_difficulty(connection_block_num)
-                {
+                let fork_range_difficulty = self.fork_range_difficulty(connection_block_num);
+                let canonical_range_difficulty =
+                    self.canonical_range_difficulty(connection_block_num);
+                if fork_range_difficulty > canonical_range_difficulty {
                     self.switch_to_fork();
                 } else {
                     self.discard_fork();


### PR DESCRIPTION
New notation for fork connection points: `x
For example, slices = ". .`c" means that at position 'b we have a downloaded slice
that starts normally as 'b, but ends as if it was 'c.
Such slice can be connected to 'a on the left, and 'd on the right.
Note: the start ID is assumed based on the position ('a, 'b etc), only the alternative end ID is specified.

Technically this modifies the IDs of the last portion of the slice (currently just the last header).
For example, if 'c normally means IDs range [384..576],
`c at position 'b ('b = [192..384]) means that the slice gets IDs in range [192..576]
In practice: 192, 193, ... 382, 575
(i.e. the last 'b header ID 383 is replaced with the last 'c header ID 575)
In this case header 382 is a fork connection point.