### PR TITLE
Downloader: previous_run_header_slices and start block adjustment.

### DIFF
--- a/src/downloader/headers_downloader/downloader_forky.rs
+++ b/src/downloader/headers_downloader/downloader_forky.rs
@@ -2,7 +2,9 @@ use super::{
     downloader_stage_loop::DownloaderStageLoop,
     headers::{
         header_slices,
-        header_slices::{align_block_num_to_slice_start, HeaderSlices},
+        header_slices::{
+            align_block_num_to_slice_start, is_block_num_aligned_to_slice_start, HeaderSlices,
+        },
     },
     headers_ui::HeaderSlicesView,
     stages::*,
@@ -101,6 +103,12 @@ impl DownloaderForky {
         ui_system: UISystemShared,
     ) -> anyhow::Result<DownloaderForkyReport> {
         let start_block_num = start_block_id.number;
+        if !is_block_num_aligned_to_slice_start(start_block_num) {
+            return Err(anyhow::format_err!(
+                "expected an aligned start block, got {}",
+                start_block_num.0
+            ));
+        }
 
         // Assuming we've downloaded all but last 90K headers in previous phases
         // we need to download them now, plus a bit more,
@@ -117,6 +125,12 @@ impl DownloaderForky {
                 fork_header_slices: previous_run_fork_header_slices,
             });
         }
+
+        // don't use previous_run_header_slices if start_block_num is outside of its range
+        let previous_run_header_slices = previous_run_header_slices
+            .filter(|slices| slices.find_by_block_num(start_block_num).is_some());
+        let previous_run_fork_header_slices =
+            previous_run_fork_header_slices.filter(|_| previous_run_header_slices.is_some());
 
         let header_slices = previous_run_header_slices.unwrap_or_else(|| {
             Arc::new(Self::make_header_slices(

--- a/src/downloader/headers_downloader/downloader_linear.rs
+++ b/src/downloader/headers_downloader/downloader_linear.rs
@@ -2,7 +2,10 @@ use super::{
     downloader_stage_loop::DownloaderStageLoop,
     headers::{
         header_slices,
-        header_slices::{align_block_num_to_slice_start, HeaderSliceStatus, HeaderSlices},
+        header_slices::{
+            align_block_num_to_slice_start, is_block_num_aligned_to_slice_start, HeaderSliceStatus,
+            HeaderSlices,
+        },
     },
     headers_ui::HeaderSlicesView,
     stages::*,
@@ -73,6 +76,12 @@ impl DownloaderLinear {
         ui_system: UISystemShared,
     ) -> anyhow::Result<DownloaderLinearReport> {
         let start_block_num = start_block_id.number;
+        if !is_block_num_aligned_to_slice_start(start_block_num) {
+            return Err(anyhow::format_err!(
+                "expected an aligned start block, got {}",
+                start_block_num.0
+            ));
+        }
 
         let trusted_len: u64 = 90_000;
 

--- a/src/downloader/headers_downloader/headers/header_slices.rs
+++ b/src/downloader/headers_downloader/headers/header_slices.rs
@@ -473,6 +473,10 @@ pub fn align_block_num_to_slice_start(num: BlockNumber) -> BlockNumber {
     BlockNumber(num.0 / slice_size * slice_size)
 }
 
+pub fn is_block_num_aligned_to_slice_start(num: BlockNumber) -> bool {
+    num.0 % (HEADER_SLICE_SIZE as u64) == 0
+}
+
 impl HeaderSlice {
     pub fn len(&self) -> usize {
         self.headers.as_ref().map_or(0, |headers| headers.len())

--- a/src/sentry/messages.rs
+++ b/src/sentry/messages.rs
@@ -74,7 +74,7 @@ pub enum Message {
 }
 
 impl Message {
-    pub fn eth_id(self: &Message) -> EthMessageId {
+    pub fn eth_id(&self) -> EthMessageId {
         match self {
             Message::NewBlockHashes(_) => EthMessageId::NewBlockHashes,
             Message::GetBlockHeaders(_) => EthMessageId::GetBlockHeaders,


### PR DESCRIPTION
If start_block_num changes between runs,
we might need to adjust the previous_run_header_slices to match.
Otherwise the downloader won't download slices that we've asked.