### PR TITLE
Downloader: fix forky slices start_block_num after restart.

### DIFF
--- a/src/downloader/headers_downloader/downloader.rs
+++ b/src/downloader/headers_downloader/downloader.rs
@@ -154,8 +154,8 @@ impl Downloader {
             .run::<RwTx>(
                 db_transaction,
                 linear_start_block_id,
-                linear_estimated_top_block_num,
                 max_blocks_count,
+                linear_estimated_top_block_num,
                 ui_system.clone(),
             )
             .await?;
@@ -170,6 +170,7 @@ impl Downloader {
                 db_transaction,
                 forky_start_block_id,
                 max_blocks_count,
+                linear_report.target_final_block_num,
                 previous_run_state
                     .as_ref()
                     .and_then(|state| state.forky_header_slices.clone()),

--- a/src/downloader/headers_downloader/downloader_linear.rs
+++ b/src/downloader/headers_downloader/downloader_linear.rs
@@ -71,8 +71,8 @@ impl DownloaderLinear {
         &'downloader self,
         db_transaction: &'downloader RwTx,
         start_block_id: BlockHashAndNumber,
-        estimated_top_block_num: Option<BlockNumber>,
         max_blocks_count: usize,
+        estimated_top_block_num: Option<BlockNumber>,
         ui_system: UISystemShared,
     ) -> anyhow::Result<DownloaderLinearReport> {
         let start_block_num = start_block_id.number;


### PR DESCRIPTION
Forky needs to download 90K headers from the tip.
If forky downloads 50% of that, next run iteration will have start_block_num
just 45K headers away from the tip.
That breaks the idea of a constant window size.

Let's start the window from where the linear phase normally ends instead.