### PR TITLE
Downloader: forky - slide full slices.

### DIFF
--- a/src/downloader/headers_downloader/downloader_tests.rs
+++ b/src/downloader/headers_downloader/downloader_tests.rs
@@ -526,8 +526,8 @@ impl HeaderGenerator {
 async fn save_verified() {
     let test = DownloaderTestDecl {
         sentry: "",
-        slices: "+   +   +   #",
-        result: "+   +   +   +",
+        slices: "+   +   +   #   -",
+        result: "+   +   +   +   -",
         forked: "",
     };
     test.run().await.unwrap();
@@ -537,8 +537,8 @@ async fn save_verified() {
 async fn verify_link() {
     let test = DownloaderTestDecl {
         sentry: "",
-        slices: "+   +   +   =",
-        result: "+   +   +   +",
+        slices: "+   +   +   =   -",
+        result: "+   +   +   +   -",
         forked: "",
     };
     test.run().await.unwrap();
@@ -548,8 +548,19 @@ async fn verify_link() {
 async fn verify_link_at_root() {
     let test = DownloaderTestDecl {
         sentry: "",
-        slices: "=",
-        result: "+",
+        slices: "=   -",
+        result: "+   -",
+        forked: "",
+    };
+    test.run().await.unwrap();
+}
+
+#[tokio::test]
+async fn slide_full() {
+    let test = DownloaderTestDecl {
+        sentry: "",
+        slices: "+   +",
+        result: "_   +   -",
         forked: "",
     };
     test.run().await.unwrap();
@@ -593,7 +604,7 @@ async fn canonical_continuation_to_top() {
     let test = DownloaderTestDecl {
         sentry: "_   _   _   .   ",
         slices: "+   +   +   ='f ",
-        result: "+   +   +   +   ",
+        result: "_   +   +   +   -   ",
         forked: "_   _   -   +'f ",
     };
     test.run().await.unwrap();
@@ -602,10 +613,10 @@ async fn canonical_continuation_to_top() {
 #[tokio::test]
 async fn fork_both_chains_continuation() {
     let test = DownloaderTestDecl {
-        sentry: "_   _   .'e .   ",
-        slices: "+   +   +   ='f ",
-        result: "+   +   +   +   ",
-        forked: "_   -   +'e +'f ",
+        sentry: "_   _   .'e .    ",
+        slices: "+   +   +   ='f -",
+        result: "+   +   +   +   -",
+        forked: "_   -   +'e +'f  ",
     };
     test.run().await.unwrap();
 }
@@ -635,9 +646,9 @@ async fn dont_fork_at_root() {
 #[tokio::test]
 async fn fork_connect_and_switch() {
     let test = DownloaderTestDecl {
-        sentry: "_   _   .`e _   ",
-        slices: "+   +   +   ='f ",
-        result: "+   +   +`e +'f ",
+        sentry: "_   _   .`e _    ",
+        slices: "+   +   +   ='f -",
+        result: "+   +   +`e +'f -",
         forked: "",
     };
     test.run().await.unwrap();
@@ -646,9 +657,9 @@ async fn fork_connect_and_switch() {
 #[tokio::test]
 async fn fork_connect_and_discard() {
     let test = DownloaderTestDecl {
-        sentry: "_   .`i .'j .   ",
-        slices: "+   +   +   ='k ",
-        result: "+   +   +   +   ",
+        sentry: "_   .`i .'j .    ",
+        slices: "+   +   +   ='k -",
+        result: "+   +   +   +   -",
         forked: "",
     };
     test.run().await.unwrap();

--- a/src/downloader/headers_downloader/stages/extend_stage.rs
+++ b/src/downloader/headers_downloader/stages/extend_stage.rs
@@ -1,0 +1,61 @@
+use super::headers::{
+    header_slice_status_watch::HeaderSliceStatusWatch,
+    header_slices::{HeaderSliceStatus, HeaderSlices},
+};
+use std::sync::Arc;
+use tracing::*;
+
+/// Extends the slices when it's full with Saved slices.
+pub struct ExtendStage {
+    header_slices: Arc<HeaderSlices>,
+    pending_watch: HeaderSliceStatusWatch,
+    remaining_count: usize,
+}
+
+impl ExtendStage {
+    pub fn new(header_slices: Arc<HeaderSlices>) -> Self {
+        Self {
+            header_slices: header_slices.clone(),
+            pending_watch: HeaderSliceStatusWatch::new(
+                HeaderSliceStatus::Saved,
+                header_slices,
+                "ExtendStage",
+            ),
+            remaining_count: 0,
+        }
+    }
+
+    pub async fn execute(&mut self) -> anyhow::Result<()> {
+        // If the number of Saved slices (pending_count) is not sufficient for extension,
+        // we need to wait until it increases.
+        // If it is sufficient (equal to header_slices len),
+        // then after extension it becomes insufficient,
+        // and we need to wait until it increases anyway.
+        // remaining_count can't suddenly become sufficient as long as
+        // this is the only stage that can change the header_slices len.
+        self.pending_watch.wait_while(self.remaining_count).await?;
+        self.remaining_count = self.pending_watch.pending_count();
+
+        if self.header_slices.all_in_status(HeaderSliceStatus::Saved) {
+            debug!("ExtendStage: extending full header slices");
+            self.header_slices.append_slice()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn can_proceed_check(&self) -> impl Fn() -> bool {
+        let header_slices = self.header_slices.clone();
+        move || -> bool { header_slices.all_in_status(HeaderSliceStatus::Saved) }
+    }
+}
+
+#[async_trait::async_trait]
+impl super::stage::Stage for ExtendStage {
+    async fn execute(&mut self) -> anyhow::Result<()> {
+        Self::execute(self).await
+    }
+    fn can_proceed_check(&self) -> Box<dyn Fn() -> bool + Send> {
+        Box::new(Self::can_proceed_check(self))
+    }
+}

--- a/src/downloader/headers_downloader/stages/fork_mode_stage.rs
+++ b/src/downloader/headers_downloader/stages/fork_mode_stage.rs
@@ -449,6 +449,17 @@ impl ForkModeStage {
         self.fork_range.start = self.fork_range.end;
     }
 
+    // If header_slices are trimmed, the fork_header_slices might need to be trimmed as well.
+    // In this case it hits the canonical chain root and needs to be discarded.
+    pub fn adjust_fork_slices_after_header_slices_trim(
+        fork_header_slices: &HeaderSlices,
+        header_slices: &HeaderSlices,
+    ) {
+        if fork_header_slices.min_block_num() <= header_slices.min_block_num() {
+            fork_header_slices.clear();
+        }
+    }
+
     fn find_canonical_continuation_slice(&self) -> Option<Arc<RwLock<HeaderSlice>>> {
         self.header_slices
             .find_by_block_num(self.canonical_range.end)

--- a/src/downloader/headers_downloader/stages/mod.rs
+++ b/src/downloader/headers_downloader/stages/mod.rs
@@ -3,6 +3,7 @@ pub mod stage;
 
 use super::{headers, verification};
 
+mod extend_stage;
 mod fetch_receive_stage;
 mod fetch_request_stage;
 mod fork_mode_stage;
@@ -17,6 +18,7 @@ mod verify_link_linear_stage;
 mod verify_preverified_stage;
 mod verify_slices_stage;
 
+pub use extend_stage::ExtendStage;
 pub use fetch_receive_stage::FetchReceiveStage;
 pub use fetch_request_stage::FetchRequestStage;
 pub use fork_mode_stage::ForkModeStage;


### PR DESCRIPTION
In forky phase when the window is full with Saved slices,
we need to slide the window up.

This is done in 2 steps:
1. during execution ExtendStage appends an empty slice to the end.
2. after execution a trim happens at the front of header slices.

It is ok to not cleanup immediately, because we need to exit processing periodically anyway.