### PR TITLE
Downloader: update db after switch to fork.

### DIFF
--- a/src/downloader/headers_downloader/downloader_tests.rs
+++ b/src/downloader/headers_downloader/downloader_tests.rs
@@ -67,9 +67,9 @@ async fn run_downloader(
         .await?;
 
     if let Some(unwind_request) = report.run_state.unwind_request.take() {
-        if let Some(finalize) = unwind_request.finalize.lock().take() {
-            finalize();
-        }
+        downloader
+            .unwind_finalize(&db_transaction, unwind_request)
+            .await?;
     }
 
     db_transaction.commit().await?;

--- a/src/stages/downloader.rs
+++ b/src/stages/downloader.rs
@@ -74,9 +74,7 @@ where
         // finalize unwind request
         if let Some(mut state) = self.load_previous_run_state().await {
             if let Some(unwind_request) = state.unwind_request.take() {
-                if let Some(finalize) = unwind_request.finalize.lock().take() {
-                    finalize();
-                }
+                self.downloader.unwind_finalize(tx, unwind_request).await?;
                 self.save_run_state(state).await;
             }
         }


### PR DESCRIPTION
CanonicalHeader / LastHeader / HeadersTotalDifficulty tables
need to be updated after switch to fork,
because they were not saved for the fork chain.
This is done as a part of unwind finalize on the next execute iteration.