### PR TITLE
Update sentry.proto to H256-based PeerId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "ethereum-interfaces"
 version = "0.1.0"
-source = "git+https://github.com/ledgerwatch/interfaces?branch=akula#4144397fc9bf8f3241df46013cabc226a5d8b1c3"
+source = "git+https://github.com/ledgerwatch/interfaces?rev=6ef398c#6ef398c682810ec616d214bc68579478a1a573f3"
 dependencies = [
  "arrayref",
  "ethereum-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ directories = "4.0"
 educe = { version = "0.4", features = ["Debug", "Default"] }
 ethash = { git = "https://github.com/rust-ethereum/ethash", branch = "ethnum" }
 ethereum-forkid = "0.7.0"
-ethereum-interfaces = { git = "https://github.com/ledgerwatch/interfaces", branch = "akula", features = [
+ethereum-interfaces = { git = "https://github.com/ledgerwatch/interfaces", rev = "6ef398c", features = [
     "remotekv",
     "sentry",
 ] }

--- a/src/sentry/sentry_client.rs
+++ b/src/sentry/sentry_client.rs
@@ -15,7 +15,7 @@ pub struct Status {
     pub max_block: BlockNumber,
 }
 
-pub type PeerId = H512;
+pub type PeerId = H256;
 
 #[derive(Clone, Debug)]
 pub enum PeerFilter {

--- a/src/sentry/sentry_client_impl.rs
+++ b/src/sentry/sentry_client_impl.rs
@@ -4,7 +4,6 @@ use super::{
     sentry_address::SentryAddress,
     sentry_client::*,
 };
-use crate::models::*;
 use async_trait::async_trait;
 use ethereum_interfaces::{sentry as grpc_sentry, types as grpc_types};
 use futures_core::Stream;
@@ -56,7 +55,7 @@ impl SentryClient for SentryClientImpl {
 
     async fn penalize_peer(&mut self, peer_id: PeerId) -> anyhow::Result<()> {
         let penalize_peer_request = grpc_sentry::PenalizePeerRequest {
-            peer_id: Some(grpc_types::H512::from(peer_id)),
+            peer_id: Some(peer_id.into()),
             penalty: grpc_sentry::PenaltyKind::Kick as i32,
         };
         let request = tonic::Request::new(penalize_peer_request);
@@ -88,7 +87,7 @@ impl SentryClient for SentryClientImpl {
             PeerFilter::PeerId(peer_id) => {
                 let request = grpc_sentry::SendMessageByIdRequest {
                     data: Some(message_data),
-                    peer_id: Some(grpc_types::H512::from(peer_id)),
+                    peer_id: Some(peer_id.into()),
                 };
                 self.client
                     .send_message_by_id(tonic::Request::new(request))
@@ -142,8 +141,8 @@ impl SentryClient for SentryClientImpl {
                     let grpc_message_id = grpc_sentry::MessageId::from_i32(inbound_message.id)
                         .ok_or_else(|| anyhow::format_err!("SentryClient receive_messages stream got an invalid MessageId {}", inbound_message.id))?;
                     let message_id = EthMessageId::try_from(grpc_message_id)?;
-                    let grpc_peer_id: Option<grpc_types::H512> = inbound_message.peer_id;
-                    let peer_id: Option<PeerId> = grpc_peer_id.map(H512::from);
+                    let grpc_peer_id: Option<grpc_types::H256> = inbound_message.peer_id;
+                    let peer_id: Option<PeerId> = grpc_peer_id.map(PeerId::from);
                     let message_bytes: bytes::Bytes = inbound_message.data;
                     let message = message_decoder::decode_rlp_message(message_id, message_bytes.as_ref())?;
                     let message_from_peer = MessageFromPeer {


### PR DESCRIPTION
The new .proto uses a 32 bytes H256 hash as a PeerId.
See https://github.com/akula-bft/sentry/issues/22