### PR TITLE
Downloader: save headers data with MDBX_APPEND.

### DIFF
--- a/src/downloader/headers_downloader/downloader_forky.rs
+++ b/src/downloader/headers_downloader/downloader_forky.rs
@@ -248,7 +248,7 @@ impl DownloaderForky {
         let save_stage = SaveStage::<RwTx>::new(
             header_slices.clone(),
             db_transaction,
-            save_stage::SaveOrder::Monotonic,
+            save_stage::SaveOrder::Random,
             true,
         );
 

--- a/src/downloader/headers_downloader/stages/fork_switch_command.rs
+++ b/src/downloader/headers_downloader/stages/fork_switch_command.rs
@@ -131,7 +131,7 @@ impl ForkSwitchCommand {
                     if header.number() <= self.connection_block_num {
                         continue;
                     }
-                    SaveStage::update_canonical_chain_header(&header, tx).await?;
+                    SaveStage::update_canonical_chain_header(&header, None, tx).await?;
                 }
             }
 


### PR DESCRIPTION
Use MutableCursor::append instead of MutableTransaction::set for SaveOrder::Monotonic.
This is supposed to speed up monotonic header slices insertions.