### PR TITLE
Add a workaround to avoid state root mismatches

### DIFF
--- a/src/trie/intermediate_hashes.rs
+++ b/src/trie/intermediate_hashes.rs
@@ -358,6 +358,11 @@ where
         changed: &mut PrefixSet,
     ) -> Result<H256> {
         let mut state = self.txn.cursor(tables::HashedStorage)?;
+
+        if state.seek_exact(H256::from_slice(key_with_inc))?.is_none() {
+            return Ok(EMPTY_ROOT);
+        }
+
         let mut trie_db_cursor = self.txn.cursor(tables::TrieStorage)?;
 
         let mut hb = HashBuilder::new(Some(Box::new(

--- a/src/trie/intermediate_hashes.rs
+++ b/src/trie/intermediate_hashes.rs
@@ -359,10 +359,6 @@ where
     ) -> Result<H256> {
         let mut state = self.txn.cursor(tables::HashedStorage)?;
 
-        if state.seek_exact(H256::from_slice(key_with_inc))?.is_none() {
-            return Ok(EMPTY_ROOT);
-        }
-
         let mut trie_db_cursor = self.txn.cursor(tables::TrieStorage)?;
 
         let mut hb = HashBuilder::new(Some(Box::new(
@@ -375,6 +371,9 @@ where
         let mut trie = Cursor::new(&mut trie_db_cursor, changed, key_with_inc)?;
         while let Some(key) = trie.key() {
             if trie.can_skip_state {
+                if state.seek_exact(H256::from_slice(key_with_inc))?.is_none() {
+                    return Ok(EMPTY_ROOT);
+                }
                 hb.add_branch_node(
                     key,
                     trie.hash().as_ref().unwrap(),


### PR DESCRIPTION
Check if the visited account is absent from HashedStorage and return
EMPTY_ROOT if that is the case. This avoids the state root mismatches
due to wrongly handled SELFDESTRUCTs we have seen.