### PR TITLE
Remove vector range checks from Stack methods

### DIFF
--- a/src/execution/evm/state.rs
+++ b/src/execution/evm/state.rs
@@ -25,13 +25,14 @@ impl Stack {
 
     #[inline]
     pub fn get(&self, pos: usize) -> &U256 {
-        &self.0[self.get_pos(pos)]
+        let pos = self.get_pos(pos);
+        unsafe { self.0.get_unchecked(pos) }
     }
 
     #[inline]
     pub fn get_mut(&mut self, pos: usize) -> &mut U256 {
         let pos = self.get_pos(pos);
-        &mut self.0[pos]
+        unsafe { self.0.get_unchecked_mut(pos) }
     }
 
     #[inline(always)]
@@ -58,7 +59,9 @@ impl Stack {
     pub fn swap_top(&mut self, pos: usize) {
         let top = self.0.len() - 1;
         let pos = self.get_pos(pos);
-        self.0.swap(top, pos);
+        unsafe {
+            self.0.swap_unchecked(top, pos);
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
     map_first_last,
     never_type,
     poll_ready,
+    slice_swap_unchecked,
     step_trait,
     type_alias_impl_trait
 )]


### PR DESCRIPTION
Checking if we are within the array bounds is redundant, since each opcode has a constant `required_stack_height` that is checked for before execution.