### PR TITLE
feat(sentry): timeout all outbound messages

### DIFF
--- a/src/p2p/node/node.rs
+++ b/src/p2p/node/node.rs
@@ -479,7 +479,8 @@ impl Node {
                 let data = data.clone();
 
                 async move {
-                    let _ = tokio::time::timeout(TIMEOUT, send_msg(sentry, predicate, data)).await?;
+                    let _ =
+                        tokio::time::timeout(TIMEOUT, send_msg(sentry, predicate, data)).await?;
                     Ok::<_, anyhow::Error>(())
                 }
             })

--- a/src/p2p/node/node.rs
+++ b/src/p2p/node/node.rs
@@ -363,8 +363,6 @@ impl Node {
     const HEADERS_PREDICATE: [i32; 1] = [grpc_sentry::MessageId::BlockHeaders66 as i32];
 
     pub async fn stream_headers(&self) -> NodeStream {
-        let _ = self.update_chain_head(None).await;
-
         let sentries = self.sentries.iter().collect::<Vec<_>>();
         SentryStream::join_all(sentries, Self::HEADERS_PREDICATE).await
     }
@@ -469,6 +467,9 @@ impl Node {
             };
             Ok::<_, anyhow::Error>(())
         };
+
+        const TIMEOUT: Duration = Duration::from_secs(2);
+
         let data = data.into();
         self.sentries
             .clone()
@@ -476,8 +477,10 @@ impl Node {
             .map(|sentry| {
                 let predicate = predicate.clone();
                 let data = data.clone();
+
                 async move {
-                    let _ = send_msg(sentry, predicate, data).await;
+                    tokio::time::timeout(TIMEOUT, send_msg(sentry, predicate, data)).await?;
+                    Ok::<_, anyhow::Error>(())
                 }
             })
             .collect::<FuturesUnordered<_>>()

--- a/src/p2p/node/node.rs
+++ b/src/p2p/node/node.rs
@@ -479,7 +479,7 @@ impl Node {
                 let data = data.clone();
 
                 async move {
-                    tokio::time::timeout(TIMEOUT, send_msg(sentry, predicate, data)).await?;
+                    let _ = tokio::time::timeout(TIMEOUT, send_msg(sentry, predicate, data)).await?;
                     Ok::<_, anyhow::Error>(())
                 }
             })


### PR DESCRIPTION
Right now, downloader(Header and Bodies) stages sometimes can get stuck. I've personally encountered that a few times, log is attached.

This PR seeks to fix that issue.

```bash
2022-05-27T07:15:28.948627Z  INFO P2P node peer info: 42 active (+39 dialing) / 8192 max.
2022-05-27T07:15:33.950020Z  INFO P2P node peer info: 40 active (+39 dialing) / 8192 max.
2022-05-27T07:15:38.950796Z  INFO P2P node peer info: 40 active (+40 dialing) / 8192 max.
2022-05-27T07:15:43.951802Z  INFO P2P node peer info: 39 active (+40 dialing) / 8192 max.
2022-05-27T07:15:48.953066Z  INFO P2P node peer info: 40 active (+42 dialing) / 8192 max.
2022-05-27T07:15:53.954155Z  INFO P2P node peer info: 41 active (+43 dialing) / 8192 max.
2022-05-27T07:15:58.954845Z  INFO P2P node peer info: 41 active (+43 dialing) / 8192 max.
2022-05-27T07:16:03.956207Z  INFO P2P node peer info: 41 active (+44 dialing) / 8192 max.
2022-05-27T07:16:08.957059Z  INFO P2P node peer info: 42 active (+44 dialing) / 8192 max.
2022-05-27T07:16:13.958503Z  INFO P2P node peer info: 43 active (+43 dialing) / 8192 max.
2022-05-27T07:16:18.960247Z  INFO P2P node peer info: 43 active (+43 dialing) / 8192 max.
2022-05-27T07:16:23.961462Z  INFO P2P node peer info: 41 active (+43 dialing) / 8192 max.
2022-05-27T07:16:28.962387Z  INFO P2P node peer info: 41 active (+43 dialing) / 8192 max.
2022-05-27T07:16:33.962846Z  INFO P2P node peer info: 42 active (+43 dialing) / 8192 max.
2022-05-27T07:16:38.964064Z  INFO P2P node peer info: 42 active (+43 dialing) / 8192 max.
2022-05-27T07:16:43.965075Z  INFO P2P node peer info: 42 active (+42 dialing) / 8192 max.
2022-05-27T07:16:48.965897Z  INFO P2P node peer info: 41 active (+42 dialing) / 8192 max.
2022-05-27T07:16:53.967669Z  INFO P2P node peer info: 42 active (+42 dialing) / 8192 max.
2022-05-27T07:16:58.969008Z  INFO P2P node peer info: 41 active (+41 dialing) / 8192 max.
2022-05-27T07:17:03.970356Z  INFO P2P node peer info: 43 active (+42 dialing) / 8192 max.
2022-05-27T07:17:08.970736Z  INFO P2P node peer info: 42 active (+41 dialing) / 8192 max.
2022-05-27T07:17:13.972518Z  INFO P2P node peer info: 43 active (+41 dialing) / 8192 max.
2022-05-27T07:17:18.974130Z  INFO P2P node peer info: 41 active (+43 dialing) / 8192 max.
2022-05-27T07:17:23.975121Z  INFO P2P node peer info: 41 active (+41 dialing) / 8192 max.
2022-05-27T07:17:28.976054Z  INFO P2P node peer info: 40 active (+38 dialing) / 8192 max.
2022-05-27T07:17:33.976975Z  INFO P2P node peer info: 41 active (+38 dialing) / 8192 max.
2022-05-27T07:17:38.978445Z  INFO P2P node peer info: 42 active (+38 dialing) / 8192 max.
2022-05-27T07:17:43.979229Z  INFO P2P node peer info: 42 active (+40 dialing) / 8192 max.
2022-05-27T07:17:48.980674Z  INFO P2P node peer info: 44 active (+42 dialing) / 8192 max.
2022-05-27T07:17:53.981865Z  INFO P2P node peer info: 42 active (+43 dialing) / 8192 max.
2022-05-27T07:17:58.982772Z  INFO P2P node peer info: 43 active (+41 dialing) / 8192 max.
2022-05-27T07:18:03.984227Z  INFO P2P node peer info: 42 active (+40 dialing) / 8192 max.
2022-05-27T07:18:08.984992Z  INFO P2P node peer info: 41 active (+40 dialing) / 8192 max.
2022-05-27T07:18:13.986628Z  INFO P2P node peer info: 42 active (+40 dialing) / 8192 max.
2022-05-27T07:18:18.987761Z  INFO P2P node peer info: 43 active (+42 dialing) / 8192 max.
2022-05-27T07:18:23.989185Z  INFO P2P node peer info: 44 active (+43 dialing) / 8192 max.
2022-05-27T07:18:28.990204Z  INFO P2P node peer info: 44 active (+43 dialing) / 8192 max.
2022-05-27T07:18:33.991130Z  INFO P2P node peer info: 42 active (+46 dialing) / 8192 max.
2022-05-27T07:18:38.991953Z  INFO P2P node peer info: 42 active (+43 dialing) / 8192 max
```