### PR TITLE
Add genesis block to AccountHistory

### DIFF
--- a/src/stages/history_index.rs
+++ b/src/stages/history_index.rs
@@ -197,7 +197,9 @@ where
         .ok_or_else(|| format_err!("Index generation cannot be the first stage"))?
         .1;
 
-    let walker = tx.cursor(data_table)?.walk(Some(starting_block + 1));
+    let walker = tx
+        .cursor(data_table)?
+        .walk(input.stage_progress.map(|x| x + 1));
     pin!(walker);
 
     let mut keys = HashMap::<IndexKey, croaring::Treemap>::new();


### PR DESCRIPTION
This PR adds the changes in the genesis block to `AccountHistory`. This is mainly useful because it allows historical state lookups to short circuit (with `None`) when the requested block is prior to the first bit of `AccountHistory`. This trick currently fails for genesis accounts.