### PR TITLE
Vectorize header validation

### DIFF
--- a/src/consensus/beacon.rs
+++ b/src/consensus/beacon.rs
@@ -215,23 +215,21 @@ impl Consensus for BeaconConsensus {
         &self,
         segment: &[crate::models::BlockHeader],
         with_future_timestamp_check: bool,
-    ) -> Result<(), super::DuoError> {
-        let failure = Mutex::new((segment.len(), Ok(())));
+    ) -> Result<(), super::DuoErrorAtHeight> {
+        let status = HeaderValidationStatus::new();
 
         segment.par_iter().enumerate().skip(1).for_each(|(i, _)| {
-            if let Err(error) = self.validate_block_header(
+            if let Err(new_error) = self.validate_block_header(
                 &segment[i - 1],
                 &segment[i],
                 with_future_timestamp_check,
             ) {
-                let mut failure = failure.lock();
-                if i < failure.0 {
-                    *failure = (i, Err(error));
-                }
+                let height = segment[i].number;
+                status.update(new_error, height);
             }
         });
 
-        failure.into_inner().1
+        status.get()
     }
 
     fn finalize(

--- a/src/consensus/beacon.rs
+++ b/src/consensus/beacon.rs
@@ -182,13 +182,12 @@ impl Consensus for BeaconConsensus {
 
     fn validate_block_headers(
         &self,
-        headers: &[crate::models::BlockHeader],
-        parent: &crate::models::BlockHeader,
+        segment: &[crate::models::BlockHeader],
         with_future_timestamp_check: bool,
     ) -> Result<(), super::DuoError> {
-        let mut parent = parent;
+        let mut parent = &segment[0];
 
-        for header in headers {
+        for header in segment.iter().skip(1) {
             self.base
                 .validate_block_header(header, parent, with_future_timestamp_check)?;
 

--- a/src/consensus/blockchain.rs
+++ b/src/consensus/blockchain.rs
@@ -55,9 +55,8 @@ impl<'state> Blockchain<'state> {
             .state
             .read_parent_header(&block.header)?
             .ok_or_else(|| format_err!("no parent header"))?;
-        let headers = vec![block.header.clone()];
-        self.engine
-            .validate_block_headers(&headers, &parent, true)?;
+        let segment = vec![parent, block.header.clone()];
+        self.engine.validate_block_headers(&segment, true)?;
         self.engine.pre_validate_block(&block, &self.state)?;
 
         let hash = block.header.hash();

--- a/src/consensus/blockchain.rs
+++ b/src/consensus/blockchain.rs
@@ -55,8 +55,9 @@ impl<'state> Blockchain<'state> {
             .state
             .read_parent_header(&block.header)?
             .ok_or_else(|| format_err!("no parent header"))?;
+        let headers = vec![block.header.clone()];
         self.engine
-            .validate_block_header(&block.header, &parent, true)?;
+            .validate_block_headers(&headers, &parent, true)?;
         self.engine.pre_validate_block(&block, &self.state)?;
 
         let hash = block.header.hash();

--- a/src/consensus/blockchain.rs
+++ b/src/consensus/blockchain.rs
@@ -56,7 +56,9 @@ impl<'state> Blockchain<'state> {
             .read_parent_header(&block.header)?
             .ok_or_else(|| format_err!("no parent header"))?;
         let segment = vec![parent, block.header.clone()];
-        self.engine.validate_block_headers(&segment, true)?;
+        self.engine
+            .validate_block_headers(&segment, true)
+            .map_err(|e| e.error)?;
         self.engine.pre_validate_block(&block, &self.state)?;
 
         let hash = block.header.hash();

--- a/src/consensus/clique/mod.rs
+++ b/src/consensus/clique/mod.rs
@@ -193,22 +193,28 @@ impl Consensus for Clique {
         Ok(())
     }
 
-    fn validate_block_header(
+    fn validate_block_headers(
         &self,
-        header: &BlockHeader,
+        headers: &[BlockHeader],
         parent: &BlockHeader,
         with_future_timestamp_check: bool,
     ) -> Result<(), DuoError> {
-        self.base
-            .validate_block_header(header, parent, with_future_timestamp_check)?;
+        let mut parent = parent;
 
-        if header.timestamp - parent.timestamp < self.period {
-            return Err(ValidationError::InvalidTimestamp {
-                parent: parent.timestamp,
-                current: header.timestamp,
-            }
-            .into());
-        };
+        for header in headers {
+            self.base
+                .validate_block_header(header, parent, with_future_timestamp_check)?;
+
+            if header.timestamp - parent.timestamp < self.period {
+                return Err(ValidationError::InvalidTimestamp {
+                    parent: parent.timestamp,
+                    current: header.timestamp,
+                }
+                .into());
+            };
+
+            parent = header;
+        }
 
         Ok(())
     }

--- a/src/consensus/clique/mod.rs
+++ b/src/consensus/clique/mod.rs
@@ -195,13 +195,12 @@ impl Consensus for Clique {
 
     fn validate_block_headers(
         &self,
-        headers: &[BlockHeader],
-        parent: &BlockHeader,
+        segment: &[BlockHeader],
         with_future_timestamp_check: bool,
     ) -> Result<(), DuoError> {
-        let mut parent = parent;
+        let mut parent = &segment[0];
 
-        for header in headers {
+        for header in segment.iter().skip(1) {
             self.base
                 .validate_block_header(header, parent, with_future_timestamp_check)?;
 

--- a/src/consensus/clique/state.rs
+++ b/src/consensus/clique/state.rs
@@ -41,7 +41,7 @@ impl Vote {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct Votes {
     votes: BTreeMap<Address, BTreeMap<Address, bool>>,
     threshold: usize,
@@ -102,7 +102,7 @@ impl Votes {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct Signers(Vec<Address>);
 
 impl Signers {
@@ -185,7 +185,7 @@ impl CliqueBlock {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct History(BTreeMap<Address, BlockNumber>);
 
 impl History {
@@ -210,7 +210,7 @@ impl History {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CliqueState {
     signers: Signers,
     history: History,

--- a/src/consensus/ethash/mod.rs
+++ b/src/consensus/ethash/mod.rs
@@ -144,48 +144,56 @@ impl Consensus for Ethash {
         Ok(())
     }
 
-    fn validate_block_header(
+    fn validate_block_headers(
         &self,
-        header: &BlockHeader,
+        headers: &[BlockHeader],
         parent: &BlockHeader,
         with_future_timestamp_check: bool,
     ) -> Result<(), DuoError> {
-        self.base
-            .validate_block_header(header, parent, with_future_timestamp_check)?;
+        let mut parent = parent;
 
-        let parent_has_uncles = parent.ommers_hash != EMPTY_LIST_HASH;
-        let difficulty = difficulty::canonical_difficulty(
-            header.number,
-            header.timestamp,
-            parent.difficulty,
-            parent.timestamp,
-            parent_has_uncles,
-            switch_is_active(self.byzantium_formula, header.number),
-            switch_is_active(self.homestead_formula, header.number),
-            self.difficulty_bomb
-                .as_ref()
-                .map(|b| BlockDifficultyBombData {
-                    delay_to: b.get_delay_to(header.number),
-                }),
-        );
-        if difficulty != header.difficulty {
-            return Err(ValidationError::WrongDifficulty.into());
-        }
+        for header in headers {
+            self.base
+                .validate_block_header(header, parent, with_future_timestamp_check)?;
 
-        if !self.skip_pow_verification {
-            let light_dag = self.dag_cache.get(header.number);
-            let (mixh, final_hash) = light_dag.hashimoto(header.truncated_hash(), header.nonce);
-
-            if mixh != header.mix_hash {
-                return Err(ValidationError::InvalidSeal.into());
+            let parent_has_uncles = parent.ommers_hash != EMPTY_LIST_HASH;
+            let difficulty = difficulty::canonical_difficulty(
+                header.number,
+                header.timestamp,
+                parent.difficulty,
+                parent.timestamp,
+                parent_has_uncles,
+                switch_is_active(self.byzantium_formula, header.number),
+                switch_is_active(self.homestead_formula, header.number),
+                self.difficulty_bomb
+                    .as_ref()
+                    .map(|b| BlockDifficultyBombData {
+                        delay_to: b.get_delay_to(header.number),
+                    }),
+            );
+            if difficulty != header.difficulty {
+                return Err(ValidationError::WrongDifficulty.into());
             }
 
-            if h256_to_u256(final_hash) > ::ethash::cross_boundary(header.difficulty) {
-                return Err(ValidationError::InvalidSeal.into());
+            if !self.skip_pow_verification {
+                let light_dag = self.dag_cache.get(header.number);
+                let (mixh, final_hash) = light_dag.hashimoto(header.truncated_hash(), header.nonce);
+
+                if mixh != header.mix_hash {
+                    return Err(ValidationError::InvalidSeal.into());
+                }
+
+                if h256_to_u256(final_hash) > ::ethash::cross_boundary(header.difficulty) {
+                    return Err(ValidationError::InvalidSeal.into());
+                }
             }
+
+            parent = header;
         }
+
         Ok(())
     }
+
     fn finalize(
         &self,
         header: &BlockHeader,

--- a/src/consensus/ethash/mod.rs
+++ b/src/consensus/ethash/mod.rs
@@ -146,13 +146,12 @@ impl Consensus for Ethash {
 
     fn validate_block_headers(
         &self,
-        headers: &[BlockHeader],
-        parent: &BlockHeader,
+        segment: &[BlockHeader],
         with_future_timestamp_check: bool,
     ) -> Result<(), DuoError> {
-        let mut parent = parent;
+        let mut parent = &segment[0];
 
-        for header in headers {
+        for header in segment.iter().skip(1) {
             self.base
                 .validate_block_header(header, parent, with_future_timestamp_check)?;
 

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -73,11 +73,13 @@ pub trait Consensus: Debug + Send + Sync + 'static {
 
     /// See YP Section 4.3.4 "Block Header Validity".
     ///
+    /// Validates a segment of the chain. The first header in the segment is supposed to be already
+    /// validated, it is only checked that it is the parent of the second.
+    ///
     /// NOTE: Shouldn't be used for genesis block.
     fn validate_block_headers(
         &self,
-        headers: &[BlockHeader],
-        parent: &BlockHeader,
+        segment: &[BlockHeader],
         with_future_timestamp_check: bool,
     ) -> Result<(), DuoError>;
 

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -74,9 +74,9 @@ pub trait Consensus: Debug + Send + Sync + 'static {
     /// See YP Section 4.3.4 "Block Header Validity".
     ///
     /// NOTE: Shouldn't be used for genesis block.
-    fn validate_block_header(
+    fn validate_block_headers(
         &self,
-        header: &BlockHeader,
+        headers: &[BlockHeader],
         parent: &BlockHeader,
         with_future_timestamp_check: bool,
     ) -> Result<(), DuoError>;

--- a/src/stages/headers.rs
+++ b/src/stages/headers.rs
@@ -365,7 +365,7 @@ impl HeaderDownload {
                     let num_headers = headers.len();
 
                     self.consensus
-                        .validate_block_headers(&headers[1..], &headers[0], true)
+                        .validate_block_headers(&headers, true)
                         .map_err(|e| match e {
                             DuoError::Validation(error) => StageError::Validation {
                                 block: BlockNumber(0), // todo
@@ -645,7 +645,7 @@ impl HeaderDownload {
         }
         if self
             .consensus
-            .validate_block_headers(&only_headers[1..], &only_headers[0], false)
+            .validate_block_headers(&only_headers, false)
             .is_err()
         {
             headers.truncate(0);

--- a/src/stages/headers.rs
+++ b/src/stages/headers.rs
@@ -366,9 +366,9 @@ impl HeaderDownload {
 
                     self.consensus
                         .validate_block_headers(&headers, true)
-                        .map_err(|e| match e {
+                        .map_err(|e| match e.error {
                             DuoError::Validation(error) => StageError::Validation {
-                                block: BlockNumber(0), // todo
+                                block: e.height,
                                 error,
                             },
                             DuoError::Internal(error) => StageError::Internal(error),
@@ -643,12 +643,9 @@ impl HeaderDownload {
         for header in headers.iter() {
             only_headers.push(header.1.clone());
         }
-        if self
-            .consensus
-            .validate_block_headers(&only_headers, false)
-            .is_err()
-        {
-            headers.truncate(0);
+        if let Err(e) = self.consensus.validate_block_headers(&only_headers, false) {
+            let error_index = e.height.0 - only_headers[0].number.0;
+            headers.truncate(error_index as usize);
         }
     }
 }


### PR DESCRIPTION
Change the signature of `Consensus::validate_block_header(s)` to validate a whole segment of the chain at once. This allows us to validate the headers in order where necessary (Clique), and to parallelize validation otherwise (Ethhash).