### PR TITLE
Enable parameterization of CL listen addr/port

### DIFF
--- a/bin/akula-toolbox.rs
+++ b/bin/akula-toolbox.rs
@@ -132,7 +132,7 @@ async fn download_headers(
         &chain_data_dir,
     )?);
     let consensus: Arc<dyn Consensus> =
-        engine_factory(Some(env.clone()), chain_config.chain_spec.clone())?.into();
+        engine_factory(Some(env.clone()), chain_config.chain_spec.clone(), None)?.into();
     let txn = env.begin_mutable()?;
     akula::genesis::initialize_genesis(
         &txn,

--- a/bin/akula.rs
+++ b/bin/akula.rs
@@ -169,8 +169,12 @@ fn main() -> anyhow::Result<()> {
                     chainspec
                 };
 
-                let consensus: Arc<dyn Consensus> =
-                    engine_factory(Some(db.clone()), chainspec.clone(), Some(opt.engine_listen_address))?.into();
+                let consensus: Arc<dyn Consensus> = engine_factory(
+                    Some(db.clone()),
+                    chainspec.clone(),
+                    Some(opt.engine_listen_address),
+                )?
+                .into();
 
                 let network_id = chainspec.params.network_id;
 

--- a/bin/akula.rs
+++ b/bin/akula.rs
@@ -105,6 +105,10 @@ pub struct Opt {
     /// Enable gRPC at this IP address and port.
     #[clap(long, default_value = "127.0.0.1:7545")]
     pub grpc_listen_address: SocketAddr,
+
+    /// Enable CL engine RPC at this IP address and port.
+    #[clap(long, default_value = "127.0.0.1:8551")]
+    pub engine_listen_address: SocketAddr,
 }
 
 #[allow(unreachable_code)]
@@ -166,7 +170,7 @@ fn main() -> anyhow::Result<()> {
                 };
 
                 let consensus: Arc<dyn Consensus> =
-                    engine_factory(Some(db.clone()), chainspec.clone())?.into();
+                    engine_factory(Some(db.clone()), chainspec.clone(), Some(opt.engine_listen_address))?.into();
 
                 let network_id = chainspec.params.network_id;
 

--- a/src/consensus/beacon.rs
+++ b/src/consensus/beacon.rs
@@ -95,6 +95,7 @@ pub struct BeaconConsensus {
 impl BeaconConsensus {
     pub fn new(
         db: Option<Arc<MdbxWithDirHandle<WriteMap>>>,
+        engine_addr: SocketAddr,
         chain_id: ChainId,
         network_id: NetworkId,
         eip1559_block: Option<BlockNumber>,
@@ -130,7 +131,7 @@ impl BeaconConsensus {
 
                     let server = HttpServerBuilder::default()
                         .set_middleware(M)
-                        .build("localhost:8551")
+                        .build(engine_addr)
                         .await
                         .unwrap();
 

--- a/src/consensus/blockchain.rs
+++ b/src/consensus/blockchain.rs
@@ -24,7 +24,7 @@ impl<'state> Blockchain<'state> {
     ) -> anyhow::Result<Blockchain<'state>> {
         Self::new_with_consensus(
             state,
-            engine_factory(None, config.clone())?,
+            engine_factory(None, config.clone(), None)?,
             config,
             genesis_block,
         )

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -17,6 +17,7 @@ use mdbx::{EnvironmentKind, TransactionKind};
 use parking_lot::Mutex;
 use std::{
     fmt::{Debug, Display},
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     sync::Arc,
 };
 use tokio::sync::watch;
@@ -310,6 +311,7 @@ pub fn pre_validate_transaction(
 pub fn engine_factory(
     db: Option<Arc<MdbxWithDirHandle<WriteMap>>>,
     chain_config: ChainSpec,
+    listen_addr: Option<SocketAddr>,
 ) -> anyhow::Result<Box<dyn Consensus>> {
     Ok(match chain_config.consensus.seal_verification {
         SealVerificationParams::Ethash {
@@ -355,6 +357,10 @@ pub fn engine_factory(
             block_reward,
         } => Box::new(BeaconConsensus::new(
             db,
+            listen_addr.unwrap_or(SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::new(127, 0, 0, 1),
+                8551,
+            ))),
             chain_config.params.chain_id,
             chain_config.params.network_id,
             chain_config.consensus.eip1559_block,

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -20,7 +20,7 @@ pub fn execute_block<S: State>(
     block: &BlockBodyWithSenders,
 ) -> Result<Vec<Receipt>, DuoError> {
     let mut analysis_cache = AnalysisCache::default();
-    let mut engine = consensus::engine_factory(None, config.clone())?;
+    let mut engine = consensus::engine_factory(None, config.clone(), None)?;
     let mut tracer = NoopTracer;
 
     let config = config.collect_block_spec(header.number);

--- a/src/execution/processor.rs
+++ b/src/execution/processor.rs
@@ -456,7 +456,7 @@ mod tests {
 
         let mut state = InMemoryState::default();
         let mut analysis_cache = AnalysisCache::default();
-        let mut engine = engine_factory(None, MAINNET.clone()).unwrap();
+        let mut engine = engine_factory(None, MAINNET.clone(), None).unwrap();
         let block_spec = MAINNET.collect_block_spec(header.number);
         let mut tracer = NoopTracer;
         let mut processor = ExecutionProcessor::new(
@@ -499,7 +499,7 @@ mod tests {
 
         let mut state = InMemoryState::default();
         let mut analysis_cache = AnalysisCache::default();
-        let mut engine = engine_factory(None, MAINNET.clone()).unwrap();
+        let mut engine = engine_factory(None, MAINNET.clone(), None).unwrap();
         let block_spec = MAINNET.collect_block_spec(header.number);
         let mut tracer = NoopTracer;
         let mut processor = ExecutionProcessor::new(
@@ -564,7 +564,7 @@ mod tests {
 
         let mut state = InMemoryState::default();
         let mut analysis_cache = AnalysisCache::default();
-        let mut engine = engine_factory(None, MAINNET.clone()).unwrap();
+        let mut engine = engine_factory(None, MAINNET.clone(), None).unwrap();
         let block_spec = MAINNET.collect_block_spec(header.number);
         let mut tracer = NoopTracer;
         let mut processor = ExecutionProcessor::new(
@@ -682,7 +682,7 @@ mod tests {
 
         let mut state = InMemoryState::default();
         let mut analysis_cache = AnalysisCache::default();
-        let mut engine = engine_factory(None, MAINNET.clone()).unwrap();
+        let mut engine = engine_factory(None, MAINNET.clone(), None).unwrap();
         let block_spec = MAINNET.collect_block_spec(header.number);
         let mut tracer = NoopTracer;
         let mut processor = ExecutionProcessor::new(
@@ -789,7 +789,7 @@ mod tests {
         };
 
         let mut analysis_cache = AnalysisCache::default();
-        let mut engine = engine_factory(None, MAINNET.clone()).unwrap();
+        let mut engine = engine_factory(None, MAINNET.clone(), None).unwrap();
         let block_spec = MAINNET.collect_block_spec(header.number);
         let mut tracer = NoopTracer;
         let mut processor = ExecutionProcessor::new(
@@ -845,7 +845,7 @@ mod tests {
 
         let mut state = InMemoryState::default();
         let mut analysis_cache = AnalysisCache::default();
-        let mut engine = engine_factory(None, MAINNET.clone()).unwrap();
+        let mut engine = engine_factory(None, MAINNET.clone(), None).unwrap();
         let block_spec = MAINNET.collect_block_spec(header.number);
         let mut tracer = NoopTracer;
         let mut processor = ExecutionProcessor::new(

--- a/src/rpc/eth.rs
+++ b/src/rpc/eth.rs
@@ -99,7 +99,7 @@ where
 
             let mut tracer = NoopTracer;
 
-            let beneficiary = engine_factory(None, chain_spec)?.get_beneficiary(&header);
+            let beneficiary = engine_factory(None, chain_spec, None)?.get_beneficiary(&header);
             Ok(evmglue::execute(
                 &mut state,
                 &mut tracer,
@@ -156,7 +156,7 @@ where
             let mut tracer = NoopTracer;
             let gas_limit = header.gas_limit;
 
-            let beneficiary = engine_factory(None, chain_spec)?.get_beneficiary(&header);
+            let beneficiary = engine_factory(None, chain_spec, None)?.get_beneficiary(&header);
             Ok(U64::from(
                 gas_limit as i64
                     - evmglue::execute(
@@ -455,7 +455,7 @@ where
                 let mut buffer = Buffer::new(&txn, Some(BlockNumber(block_number.0 - 1)));
 
                 let block_execution_spec = chain_spec.collect_block_spec(block_number);
-                let mut engine = engine_factory(None, chain_spec)?;
+                let mut engine = engine_factory(None, chain_spec, None)?;
                 let mut analysis_cache = AnalysisCache::default();
                 let mut tracer = NoopTracer;
 

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -264,7 +264,7 @@ pub mod helpers {
         let mut buffer = Buffer::new(txn, Some(BlockNumber(block_number.0 - 1)));
 
         let block_execution_spec = chain_spec.collect_block_spec(block_number);
-        let mut engine = engine_factory(None, chain_spec)?;
+        let mut engine = engine_factory(None, chain_spec, None)?;
         let mut analysis_cache = AnalysisCache::default();
         let mut tracer = NoopTracer;
 

--- a/src/rpc/otterscan.rs
+++ b/src/rpc/otterscan.rs
@@ -58,7 +58,7 @@ where
         let chainspec = tx
             .get(tables::Config, ())?
             .ok_or_else(|| format_err!("no chainspec found"))?;
-        let finalization_changes = engine_factory(None, chainspec)?.finalize(&header, &ommers)?;
+        let finalization_changes = engine_factory(None, chainspec, None)?.finalize(&header, &ommers)?;
 
         let mut block_reward = U256::ZERO;
         let mut uncle_reward = U256::ZERO;
@@ -172,7 +172,7 @@ where
         last_page: false,
     };
 
-    let beneficiary = engine_factory(None, chain_spec.clone())?.get_beneficiary(&header);
+    let beneficiary = engine_factory(None, chain_spec.clone(), None)?.get_beneficiary(&header);
 
     for (transaction_index, (transaction, sender)) in messages.into_iter().zip(senders).enumerate()
     {
@@ -434,7 +434,7 @@ where
                 let mut buffer = Buffer::new(&txn, Some(BlockNumber(block_number.0 - 1)));
 
                 let block_execution_spec = chain_spec.collect_block_spec(block_number);
-                let mut engine = engine_factory(None, chain_spec)?;
+                let mut engine = engine_factory(None, chain_spec, None)?;
                 let mut analysis_cache = AnalysisCache::default();
                 let mut tracer = NoopTracer;
 

--- a/src/rpc/otterscan.rs
+++ b/src/rpc/otterscan.rs
@@ -58,7 +58,8 @@ where
         let chainspec = tx
             .get(tables::Config, ())?
             .ok_or_else(|| format_err!("no chainspec found"))?;
-        let finalization_changes = engine_factory(None, chainspec, None)?.finalize(&header, &ommers)?;
+        let finalization_changes =
+            engine_factory(None, chainspec, None)?.finalize(&header, &ommers)?;
 
         let mut block_reward = U256::ZERO;
         let mut uncle_reward = U256::ZERO;

--- a/src/rpc/trace.rs
+++ b/src/rpc/trace.rs
@@ -259,7 +259,7 @@ where
     let block_spec = chain_spec.collect_block_spec(block_number);
     let mut buffer = Buffer::new(txn, historical_block);
 
-    let engine = engine_factory(None, chain_spec.clone())?;
+    let engine = engine_factory(None, chain_spec.clone(), None)?;
 
     let mut analysis_cache = AnalysisCache::default();
     for (sender, message, trace_types) in calls {
@@ -383,7 +383,7 @@ where
 
     let mut rewards = vec![];
     if let Some(ommers) = finalization {
-        for change in engine_factory(None, chain_spec)?.finalize(&header, &ommers)? {
+        for change in engine_factory(None, chain_spec, None)?.finalize(&header, &ommers)? {
             match change {
                 crate::consensus::FinalizationChange::Reward {
                     address,

--- a/src/sentry/devp2p/disc/dns/mod.rs
+++ b/src/sentry/devp2p/disc/dns/mod.rs
@@ -261,13 +261,12 @@ impl<K: EnrKeyUnambiguous> FromStr for DnsRecord<K> {
 
         if let Some(link) = s.strip_prefix(LINK_PREFIX) {
             let mut it = link.split('@');
-            let public_key = K::decode_public(
-                &BASE32_NOPAD.decode(
+            let public_key =
+                K::decode_public(&BASE32_NOPAD.decode(
                     it.next()
                         .ok_or_else(|| anyhow!("Public key not found"))?
                         .as_bytes(),
-                )?,
-            )?;
+                )?)?;
             let domain = it
                 .next()
                 .ok_or_else(|| anyhow!("Domain not found"))?

--- a/src/sentry/devp2p/disc/dns/mod.rs
+++ b/src/sentry/devp2p/disc/dns/mod.rs
@@ -261,12 +261,13 @@ impl<K: EnrKeyUnambiguous> FromStr for DnsRecord<K> {
 
         if let Some(link) = s.strip_prefix(LINK_PREFIX) {
             let mut it = link.split('@');
-            let public_key =
-                K::decode_public(&BASE32_NOPAD.decode(
+            let public_key = K::decode_public(
+                &BASE32_NOPAD.decode(
                     it.next()
                         .ok_or_else(|| anyhow!("Public key not found"))?
                         .as_bytes(),
-                )?)?;
+                )?,
+            )?;
             let domain = it
                 .next()
                 .ok_or_else(|| anyhow!("Domain not found"))?

--- a/src/stages/execution.rs
+++ b/src/stages/execution.rs
@@ -42,7 +42,7 @@ fn execute_batch_of_blocks<E: EnvironmentKind>(
     starting_block: BlockNumber,
     first_started_at: (Instant, Option<BlockNumber>),
 ) -> Result<BlockNumber, StageError> {
-    let mut consensus_engine = engine_factory(None, chain_config.clone())?;
+    let mut consensus_engine = engine_factory(None, chain_config.clone(), None)?;
     consensus_engine.set_state(ConsensusState::recover(tx, &chain_config, starting_block)?);
 
     let mut buffer = Buffer::new(tx, None);


### PR DESCRIPTION
The CL RPC is currently hardcoded to listen on localhost:8551. While it is a good default, and we should keep it, that does not work with docker compose, because each container gets its own IP from internal network, it needs to bind to the container IP.

This PR adds a parameter to CL engine address/port. It is not that good solution, but it works and does minimal changes to other parts of the code. The challenge here is to inject the address/port param into the beacon consensus object, I think a better approach would require a bigger refactoring/cleanup, but I'm not ready for that :)

It only modifies the engine_factory function signature and adds default params to other callers, so it keeps current code semantics while enabling the akula binary to pass the new param.