### PR TITLE
Add missing feature to enable deriving `Default` on enums

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
     assert_matches,
     const_for,
     const_mut_refs,
+    derive_default_enum,
     entry_insert,
     generator_trait,
     generators,


### PR DESCRIPTION
Fixed compilation error.

Requires upstream PR
https://github.com/vorot93/ethereum-jsonrpc/pull/3