### PR TITLE
Add support for more cpu architectures.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ ethereum-types = { version = "0.13", features = ["codec"] }
 ethereum-jsonrpc = { git = "https://github.com/vorot93/ethereum-jsonrpc", features = [
   "server",
 ] }
-ethnum = { version = "1", features = ["llvm-intrinsics", "rlp", "scale"] }
+ethnum = { version = "1", features = ["rlp", "scale"] }
 fastrlp = { version = "0.1", features = [
   "derive",
   "ethereum-types",


### PR DESCRIPTION
llvm generated code for large Integers is using naive methods anyway. More seriously, please stop reinvent the wheel and use gmp which with the hand written assembly for nearly all gnu supported architectures is the de facto standard for several decades.

Rust bindings already exists.