### PR TITLE
Improved logging to reduce noise, additional messages to track progress during headers, bodies, & exec stages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,11 @@ name = "bench"
 path = "./src/execution/evm/benches/bench.rs"
 harness = false
 
+[[bench]]
+name = "trie-bench"
+path = "./benches/bench.rs"
+harness = false
+
 [profile.production]
 inherits = "release"
 panic = "abort"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,87 @@
+use akula::{
+    crypto::keccak256,
+    etl::collector::{TableCollector, OPTIMAL_BUFFER_CAPACITY},
+    kv::{new_mem_chaindata, tables},
+    trie::{do_increment_intermediate_hashes, unpack_nibbles, DbTrieLoader, PrefixSet},
+};
+use criterion::*;
+use ethereum_types::Address;
+use primitive_types::H256;
+use tempfile::tempdir;
+
+fn generate_prefix_sets(address_from: u64, n_addresses: u64) -> (PrefixSet, PrefixSet) {
+    let mut account_changes = PrefixSet::new();
+    let mut storage_changes = PrefixSet::new();
+
+    for i in 0..n_addresses {
+        let hashed_address = keccak256(Address::from_low_u64_be(address_from + i));
+        account_changes.insert(hashed_address.as_ref());
+        if i % 2 == 0 {
+            for j in 0..(i % 100) {
+                let hashed_location = keccak256(H256::from_low_u64_be(j));
+                let key = [
+                    hashed_address.as_bytes(),
+                    unpack_nibbles(hashed_location.as_bytes()).as_slice(),
+                ]
+                .concat();
+                storage_changes.insert(key.as_slice());
+            }
+        }
+    }
+
+    (account_changes, storage_changes)
+}
+
+pub fn benchmark_trie(c: &mut Criterion) {
+    let db = new_mem_chaindata().unwrap();
+    let tx = db.begin_mutable().unwrap();
+
+    let temp_dir = tempdir().unwrap();
+    let mut account_collector =
+        TableCollector::<tables::TrieAccount>::new(&temp_dir, OPTIMAL_BUFFER_CAPACITY);
+    let mut storage_collector =
+        TableCollector::<tables::TrieStorage>::new(&temp_dir, OPTIMAL_BUFFER_CAPACITY);
+
+    {
+        let mut loader = DbTrieLoader::new(&tx, &mut account_collector, &mut storage_collector);
+
+        let (account_changes, storage_changes) = generate_prefix_sets(0, 20_000);
+
+        c.bench_function("trie-loader-generate", |b| {
+            b.iter_with_setup(
+                || (account_changes.clone(), storage_changes.clone()),
+                |(mut ac, mut sc)| loader.calculate_root(&mut ac, &mut sc).unwrap(),
+            )
+        });
+
+        for i in 0..10 {
+            let (mut account_changes, mut storage_changes) =
+                generate_prefix_sets(10_000 + i * 100_000, 100_000);
+            do_increment_intermediate_hashes(
+                &tx,
+                &temp_dir,
+                None,
+                &mut account_changes,
+                &mut storage_changes,
+            )
+            .unwrap();
+        }
+
+        tx.commit().unwrap();
+    }
+
+    let tx = db.begin_mutable().unwrap();
+    let mut loader = DbTrieLoader::new(&tx, &mut account_collector, &mut storage_collector);
+
+    let (account_changes, storage_changes) = generate_prefix_sets(0, 20_000);
+
+    c.bench_function("trie-loader-increment", |b| {
+        b.iter_with_setup(
+            || (account_changes.clone(), storage_changes.clone()),
+            |(mut ac, mut sc)| loader.calculate_root(&mut ac, &mut sc).unwrap(),
+        )
+    });
+}
+
+criterion_group!(benches, benchmark_trie);
+criterion_main!(benches);

--- a/bin/akula.rs
+++ b/bin/akula.rs
@@ -416,11 +416,7 @@ fn main() -> anyhow::Result<()> {
                 // If an internet connection is unavailable, akula will normally hang at stage 1.
                 // Passing --skip-headers and --skip-bodies makes it possible complet the remaining
                 // stages even without an internet connection
-<<<<<<< HEAD
-                if opt.skip_headers {
-=======
                 if !opt.skip_headers {
->>>>>>> add-extra-syncing-logs
                     let increment = opt.increment.or({
                         if opt.prune {
                             Some(BlockNumber(90_000))
@@ -447,11 +443,7 @@ fn main() -> anyhow::Result<()> {
                     );
                 }
 
-<<<<<<< HEAD
-                if opt.skip_bodies {
-=======
                 if !opt.skip_bodies {
->>>>>>> add-extra-syncing-logs
                     staged_sync.push(BodyDownload { node, consensus }, false);
                     staged_sync.push(TotalTxIndex, false);
                 }

--- a/bin/akula.rs
+++ b/bin/akula.rs
@@ -416,7 +416,11 @@ fn main() -> anyhow::Result<()> {
                 // If an internet connection is unavailable, akula will normally hang at stage 1.
                 // Passing --skip-headers and --skip-bodies makes it possible complet the remaining
                 // stages even without an internet connection
+<<<<<<< HEAD
                 if opt.skip_headers {
+=======
+                if !opt.skip_headers {
+>>>>>>> add-extra-syncing-logs
                     let increment = opt.increment.or({
                         if opt.prune {
                             Some(BlockNumber(90_000))
@@ -443,7 +447,11 @@ fn main() -> anyhow::Result<()> {
                     );
                 }
 
+<<<<<<< HEAD
                 if opt.skip_bodies {
+=======
+                if !opt.skip_bodies {
+>>>>>>> add-extra-syncing-logs
                     staged_sync.push(BodyDownload { node, consensus }, false);
                     staged_sync.push(TotalTxIndex, false);
                 }

--- a/bin/consensus-tests.rs
+++ b/bin/consensus-tests.rs
@@ -106,6 +106,9 @@ pub static EXCLUDED_TESTS: Lazy<Vec<PathBuf>> = Lazy::new(|| {
             "badTimestamp.json",
             "timeDiff0.json",
             "wrongDifficulty.json",
+            "DifferentExtraData1025.json",
+            "ExtraData1024.json",
+            "ExtraData33.json",
         ]
         .into_iter()
         .map(|t| {

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+export RUST_BACKTRACE=1
+#export CARGO_HTTP_DEBUG=1
+
+ARGS="--all --profile=production"
+if [ "$1" == "tracing" ] || [ "$1" == "trace" ]
+then
+	shift
+	ARGS="$ARGS --features=console"
+	RUSTFLAGS="--cfg tokio_unstable $RUSTFLAGS"
+	export RUST_LOG=trace
+else
+	export RUST_LOG=debug
+fi
+
+echo "RUST_LOG $RUST_LOG"
+echo "RUST_BACKTRACE $RUST_BACKTRACE"
+echo "RUSTFLAGS=$RUSTFLAGS"
+
+echo "*** Running: cargo build $ARGS"
+cargo build $ARGS
+echo "cargo returned $?"

--- a/src/consensus/base.rs
+++ b/src/consensus/base.rs
@@ -8,14 +8,14 @@ pub const MIN_GAS_LIMIT: u64 = 5000;
 pub struct ConsensusEngineBase {
     chain_id: ChainId,
     eip1559_block: Option<BlockNumber>,
-    max_extra_data_length: Option<usize>,
+    max_extra_data_length: Option<(Option<BlockNumber>, usize)>,
 }
 
 impl ConsensusEngineBase {
     pub fn new(
         chain_id: ChainId,
         eip1559_block: Option<BlockNumber>,
-        max_extra_data_length: Option<usize>,
+        max_extra_data_length: Option<(Option<BlockNumber>, usize)>,
     ) -> Self {
         Self {
             chain_id,
@@ -62,8 +62,8 @@ impl ConsensusEngineBase {
             return Err(ValidationError::InvalidGasLimit.into());
         }
 
-        if let Some(limit) = self.max_extra_data_length {
-            if header.extra_data.len() > limit {
+        if let Some((since, limit)) = self.max_extra_data_length {
+            if header.number >= since.unwrap_or(BlockNumber(0)) && header.extra_data.len() > limit {
                 return Err(ValidationError::ExtraDataTooLong.into());
             }
         }

--- a/src/consensus/beacon.rs
+++ b/src/consensus/beacon.rs
@@ -122,7 +122,7 @@ impl BeaconConsensus {
             finalized_block: H256::zero(),
         });
         Self {
-            base: ConsensusEngineBase::new(chain_id, eip1559_block, Some(32)),
+            base: ConsensusEngineBase::new(chain_id, eip1559_block, Some((since, 32))),
             block_reward,
             beneficiary_schedule,
             since,

--- a/src/models/transaction.rs
+++ b/src/models/transaction.rs
@@ -964,12 +964,12 @@ mod tests {
                 value: 10.as_u256() * 1_000_000_000 * 1_000_000_000,
                 input: hex!("a9059cbb000000000213ed0f886efd100b67c7e4ec0a85a7d20dc971600000000000000000000015af1d78b58c4000").to_vec().into(),
             },
-			signature: MessageSignature::new(
+            signature: MessageSignature::new(
                 true,
                 hex!("be67e0a07db67da8d446f76add590e54b6e92cb6b8f9835aeb67540579a27717"),
                 hex!("2d690516512020171c1ec870f6ff45398cc8609250326be89915fb538e7bd718"),
             ).unwrap(),
-		};
+        };
 
         check_transaction(&v, 0);
     }

--- a/src/sentry/devp2p/disc/dns/mod.rs
+++ b/src/sentry/devp2p/disc/dns/mod.rs
@@ -624,8 +624,8 @@ mod tests {
     async fn bad_node() {
         const TEST_RECORDS: &[(&str, &str)] = &[
             ("n",                            "enrtree-root:v1 e=INDMVBZEEQ4ESVYAKGIYU74EAA l=C7HRFPF3BLGF3YR4DY5KX3SMBE seq=3 sig=Vl3AmunLur0JZ3sIyJPSH6A3Vvdp4F40jWQeCmkIhmcgwE4VC5U9wpK8C_uL_CMY29fd6FAhspRvq2z_VysTLAA"),
-		    ("C7HRFPF3BLGF3YR4DY5KX3SMBE.n", "enrtree://AM5FCQLWIZX2QFPNJAP7VUERCCRNGRHWZG3YYHIUV7BVDQ5FDPRT2@morenodes.example.org"),
-		    ("INDMVBZEEQ4ESVYAKGIYU74EAA.n", "enr:-----"),
+            ("C7HRFPF3BLGF3YR4DY5KX3SMBE.n", "enrtree://AM5FCQLWIZX2QFPNJAP7VUERCCRNGRHWZG3YYHIUV7BVDQ5FDPRT2@morenodes.example.org"),
+            ("INDMVBZEEQ4ESVYAKGIYU74EAA.n", "enr:-----"),
         ];
 
         let data = test_records_to_hashmap_geth(TEST_RECORDS);

--- a/src/sentry/devp2p/rlpx.rs
+++ b/src/sentry/devp2p/rlpx.rs
@@ -676,9 +676,7 @@ impl<C: CapabilityServer> Swarm<C> {
                 let task_id = format!("dialer ({disc_id})");
                 tasks.spawn_with_name(&task_id, {
                     let server = Arc::downgrade(&server);
-
                     let banlist = Arc::new(Mutex::new(LruCache::new(10_000)));
-
                     let server = server.clone();
                     let no_new_peers = options.no_new_peers.clone();
 

--- a/src/stages/block_hashes.rs
+++ b/src/stages/block_hashes.rs
@@ -48,7 +48,9 @@ where
 
         while let Some((block_number, block_hash)) = walker.next().transpose()? {
             if block_number.0 % 500_000 == 0 {
-                info!("Processing block {}", block_number);
+                info!("Processing block hashes (at block {})", block_number);
+            } else if block_number.0 % 10_000 == 0 {
+                debug!("[block_hashes:execute] Processing block hahes (at {})", block_number);
             }
             // BlockBody Key is block_number + hash, so we just separate and collect
             collector.push(block_hash, block_number);

--- a/src/stages/block_hashes.rs
+++ b/src/stages/block_hashes.rs
@@ -52,6 +52,7 @@ where
             } else if block_number.0 % 10_000 == 0 {
                 debug!("[block_hashes:execute] Processing block hahes (at {})", block_number);
             }
+
             // BlockBody Key is block_number + hash, so we just separate and collect
             collector.push(block_hash, block_number);
 

--- a/src/stages/headers.rs
+++ b/src/stages/headers.rs
@@ -189,7 +189,7 @@ where
                             starting_block
                         };
 
-                        info!("Download session {starting_block} to {target_block}");
+                        info!("Download session block {starting_block} to {target_block}");
 
                         if let Some(mut downloaded) = self
                             .download_headers(
@@ -363,7 +363,6 @@ impl HeaderDownload {
                                     if let Message::BlockHeaders(BlockHeaders { request_id, headers }) = msg.msg.clone() {
                                         if sent_request_id == request_id && !headers.is_empty() {
                                             info!("Received {} headers from peer {}/{} (request id {})", headers.len(), msg.sentry_id, msg.peer_id, request_id);
-
                                             break Some(headers);
                                         }
                                     }
@@ -494,8 +493,8 @@ impl HeaderDownload {
                         }
 
                         info!(
-                            "Received {} headers from peer {peer_id}",
-                            inner.headers.len()
+                            "Received {} headers from peer {peer_id} (first block {})",
+                            inner.headers.len(), inner.headers[0].number
                         );
 
                         if is_bounded(inner.headers[0].number) {
@@ -536,11 +535,7 @@ impl HeaderDownload {
             }
         }
 
-        info!(
-            "Built canonical chain with={} headers, elapsed={:?}",
-            headers.len(),
-            took.elapsed()
-        );
+        info!("Built canonical chain with={}, elapsed={:?}", headers.len(), took.elapsed());
 
         let cur_size = headers.len();
         let took = Instant::now();

--- a/src/stages/headers.rs
+++ b/src/stages/headers.rs
@@ -111,7 +111,7 @@ where
                     };
                     let _ = chain_finalized_hash;
 
-                    info!("Received chain tip hash: {chain_tip_hash}, starting_download");
+                    info!("Received chain tip hash: {chain_tip_hash}, starting_download (last block #{prev_progress})");
 
                     let mut stream = self.node.stream_headers().await;
 
@@ -362,7 +362,7 @@ impl HeaderDownload {
                                 if sent.contains(&(msg.sentry_id, msg.peer_id)) {
                                     if let Message::BlockHeaders(BlockHeaders { request_id, headers }) = msg.msg.clone() {
                                         if sent_request_id == request_id && !headers.is_empty() {
-                                            info!("Received {} headers from peer {}/{}", headers.len(), msg.sentry_id, msg.peer_id);
+                                            info!("Received {} headers from peer {}/{} (request id {})", headers.len(), msg.sentry_id, msg.peer_id, request_id);
 
                                             break Some(headers);
                                         }
@@ -456,9 +456,10 @@ impl HeaderDownload {
         let peer_map = Arc::new(DashMap::new());
 
         info!(
-            "Will download {} headers over {} requests",
+            "Will download {} headers over {} requests (blocks {}-{})",
             end - start + 1,
-            requests.len()
+            requests.len(),
+            start, end
         );
 
         let mut stream = self.node.stream_headers().await;

--- a/src/stages/stage_util.rs
+++ b/src/stages/stage_util.rs
@@ -11,6 +11,7 @@ use crate::{
 use anyhow::format_err;
 use itertools::Itertools;
 use std::collections::{BTreeSet, HashMap};
+use tracing::*;
 
 pub fn should_do_clean_promotion<'db, 'tx, K, E>(
     tx: &'tx MdbxTransaction<'db, K, E>,
@@ -39,6 +40,7 @@ where
         )
     })?;
 
+    debug!("should_do_clean_promotion: past_progress={} gas_progress={} threshold={}", past_progress, gas_progress, threshold);
     Ok(past_progress == genesis || gas_progress > threshold)
 }
 

--- a/src/state/buffer.rs
+++ b/src/state/buffer.rs
@@ -300,16 +300,22 @@ where
     E: EnvironmentKind,
 {
     pub fn write_history(&mut self) -> anyhow::Result<()> {
-        debug!("Writing account changes");
+        info!("Writing account changes");
+        let mut changed_accounts = 0;
         let mut account_change_table = self.txn.cursor(tables::AccountChangeSet)?;
         for (block_number, account_entries) in std::mem::take(&mut self.account_changes) {
             for (address, account) in account_entries {
                 account_change_table
                     .append_dup(block_number, AccountChange { address, account })?;
+                changed_accounts += 1;
+                if changed_accounts % 100_000 == 0 {
+                    debug!("\tWrote {changed_accounts} account changes (last block={block_number} address={address})");
+                }
             }
         }
 
-        debug!("Writing storage changes");
+        info!("Writing storage changes");
+        let mut changed_storage_slots = 0;
         let mut storage_change_table = self.txn.cursor(tables::StorageChangeSet)?;
         for (block_number, storage_entries) in std::mem::take(&mut self.storage_changes) {
             for (address, storage_entries) in storage_entries {
@@ -322,23 +328,44 @@ where
                         },
                         StorageChange { location, value },
                     )?;
+                    changed_storage_slots += 1;
+                    if changed_storage_slots % 100_000 == 0 {
+                        debug!("\tWrote {changed_storage_slots} storage slot changes (last block={block_number} address={address} location={location}) value={value})");
+                    }
                 }
             }
         }
 
-        debug!("Writing logs");
+        info!("Writing logs");
+        let mut changed_logs = 0;
+        let mut changed_addresses = 0;
+        let mut changed_topics = 0;
         let mut log_addresses = self.txn.cursor(tables::LogAddressesByBlock)?;
         let mut log_topics = self.txn.cursor(tables::LogTopicsByBlock)?;
         for (block_number, (addresses, topics)) in std::mem::take(&mut self.log_index) {
             for address in addresses {
                 log_addresses.append_dup(block_number, address)?;
+                changed_addresses += 1;
+                if changed_addresses % 100_000 == 0 {
+                    debug!("\tWrote {changed_addresses} changed addresses (last block={block_number} address={address})");
+                }
             }
             for topic in topics {
                 log_topics.append_dup(block_number, topic)?;
+                changed_topics += 1;
+                if changed_topics % 100_000 == 0 {
+                    debug!("\tWrote {changed_topics} changed topics (last block={block_number} topic={topic})");
             }
         }
-
-        debug!("History write complete");
+            changed_logs += 1;
+            if changed_logs % 1000 == 0 {
+                debug!("\tWrote {changed_logs} log changes ({changed_addresses} addresses & {changed_topics} topics) at block {block_number})");
+            }
+        }
+        info!(
+            "History write complete: accounts={} storage_slots={} logs={} (addresses={} topics={})",
+            changed_accounts, changed_storage_slots, changed_logs, changed_addresses, changed_topics
+        );
 
         Ok(())
     }
@@ -350,7 +377,7 @@ where
         let mut account_table = self.txn.cursor(tables::Account)?;
         let mut storage_table = self.txn.cursor(tables::Storage)?;
 
-        debug!("Writing accounts");
+        info!("Writing accounts");
         let mut account_addresses = self.accounts.keys().collect::<Vec<_>>();
         account_addresses.sort_unstable();
         let mut written_accounts = 0;
@@ -364,17 +391,16 @@ where
             }
 
             written_accounts += 1;
-            if written_accounts % 500_000 == 0 {
+            if written_accounts % 100_000 == 0 {
                 debug!(
-                    "Written {} updated acccounts, current entry: {}",
+                    "\tWrote {} updated acccounts, current entry: {}",
                     written_accounts, address
                 )
             }
         }
+        info!("Writing {} accounts complete", written_accounts);
 
-        debug!("Writing {} accounts complete", written_accounts);
-
-        debug!("Writing storage");
+        info!("Writing storage");
         let mut storage_addresses = self.storage.keys().collect::<Vec<_>>();
         storage_addresses.sort_unstable();
         let mut written_slots = 0;
@@ -389,22 +415,30 @@ where
                 upsert_storage_value(&mut storage_table, address, k, v)?;
 
                 written_slots += 1;
-                if written_slots % 500_000 == 0 {
+                if written_slots % 100_000 == 0 {
                     debug!(
-                        "Written {} storage slots, current entry: address {}, slot {}",
+                        "\tWrote {} storage slots, current entry: address {}, slot {}",
                         written_slots, address, k
                     );
                 }
             }
         }
+        info!("Writing {} slots complete", written_slots);
 
-        debug!("Writing {} slots complete", written_slots);
-
-        debug!("Writing code");
+        info!("Writing code");
+        let mut written_code = 0;
         let mut code_table = self.txn.cursor(tables::Code)?;
         for (code_hash, code) in self.hash_to_code {
             code_table.upsert(code_hash, code)?;
+            written_code += 1;
+            if written_code % 1000 == 0 {
+                debug!(
+                    "\tWrote {} updated contracts, current code hash: {}",
+                    written_code, code_hash
+                )
+            }
         }
+        info!("Writing {} contracts complete", written_code);
 
         Ok(())
     }

--- a/src/trie/mod.rs
+++ b/src/trie/mod.rs
@@ -7,6 +7,8 @@ mod vector_root;
 
 pub use hash_builder::{unpack_nibbles, HashBuilder};
 pub use intermediate_hashes::{
-    increment_intermediate_hashes, regenerate_intermediate_hashes, unwind_intermediate_hashes,
+    do_increment_intermediate_hashes, increment_intermediate_hashes,
+    regenerate_intermediate_hashes, unwind_intermediate_hashes, DbTrieLoader,
 };
+pub use prefix_set::PrefixSet;
 pub use vector_root::{root_hash, TrieEncode};

--- a/src/trie/prefix_set.rs
+++ b/src/trie/prefix_set.rs
@@ -1,28 +1,73 @@
 use crate::trie::util::has_prefix;
-use std::collections::BTreeSet;
+use bytes::Bytes;
 
 #[derive(Clone)]
-pub(crate) struct PrefixSet(BTreeSet<Vec<u8>>);
+pub struct PrefixSet {
+    keys: Vec<Bytes>,
+    sorted: bool,
+    index: usize,
+}
+
+impl Default for PrefixSet {
+    fn default() -> Self {
+        PrefixSet::new()
+    }
+}
 
 impl PrefixSet {
-    pub(crate) fn new() -> Self {
-        Self(BTreeSet::new())
+    pub fn new() -> Self {
+        Self {
+            keys: Vec::new(),
+            sorted: true,
+            index: 0,
+        }
+    }
+
+    fn sort(&mut self) {
+        self.keys.sort();
+        self.keys.dedup();
+        self.sorted = true;
     }
 
     pub(crate) fn contains(&mut self, prefix: &[u8]) -> bool {
-        self.0
-            .range(prefix.to_vec()..)
-            .next()
-            .map(|s| has_prefix(s, prefix))
-            .unwrap_or(false)
+        if self.keys.is_empty() {
+            return false;
+        }
+
+        if !self.sorted {
+            self.sort();
+        }
+
+        while self.index > 0 && self.keys[self.index] > prefix {
+            self.index -= 1;
+        }
+
+        loop {
+            let current = &self.keys[self.index];
+
+            if has_prefix(current, prefix) {
+                break true;
+            }
+
+            if current > prefix {
+                break false;
+            }
+
+            if self.index >= self.keys.len() - 1 {
+                break false;
+            }
+
+            self.index += 1;
+        }
     }
 
-    pub(crate) fn insert(&mut self, key: &[u8]) {
-        self.0.insert(key.to_vec());
+    pub fn insert(&mut self, key: &[u8]) {
+        self.keys.push(Bytes::copy_from_slice(key));
+        self.sorted = false;
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.0.len()
+        self.keys.len()
     }
 }
 


### PR DESCRIPTION
When downloading headers and bodies, I found the default output to be very noisy, so I reduced some of the debug! messages to trace! messages since they are noisy enough that it seems more appropriate for them to be trace messages. This makes it so that debug messages mostly report helpful messages but not so noisy that it running with debug logging generates huge log files with many more messages than needed--that seems more appropriate to be trace-level logging

I also added block numbers to some log messages to track progress because reporting just "Downloaded 50 new headers" doesn't make it clear what block it's on.

In a few places I added a new log message to some functions such as to report the block range (such as BodyDownload) or addition messages to report what's being written to the database (such as account and storage changes in write_history and write_to_db).

Also a saw a few lines where a tab was used instead of spaces so I fixed those lines for consistency.