### PR TITLE
Optimize historical state access

### DIFF
--- a/src/state/buffer.rs
+++ b/src/state/buffer.rs
@@ -612,6 +612,18 @@ mod tests {
                     buffer.read_storage(address, location).unwrap(),
                     expected_value
                 );
+
+                assert_eq!(
+                    accessors::state::account::walk(
+                        &txn,
+                        Some(address),
+                        Some(historical_block.into())
+                    )
+                    .next()
+                    .transpose()
+                    .unwrap(),
+                    expected_account.map(|acc| (address, acc))
+                );
             }
         }
     }


### PR DESCRIPTION
The account and storage gRPC streams were broken for historical blocks due to a typo (`!=` rather than `==`). This PR fixes that. I've also implemented two optimizations:

1. If the history index shows that the requested block is older than the first write to an account/storage key `None`/`U256::ZERO` can be returned immediately.
2. Since the `walk()` functions are already iterating over the history index they can efficiently identify which block to find changesets in, which is more efficient that calling `read()` which then has to do a history index lookup itself.