### PR TITLE
Reuse memory for EVM stack and memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
  "include_dir",
  "itertools",
  "jsonrpsee",
+ "libc",
  "libmdbx",
  "lru",
  "maplit",
@@ -1287,7 +1288,6 @@ dependencies = [
 [[package]]
 name = "ethereum-interfaces"
 version = "0.1.0"
-source = "git+https://github.com/ledgerwatch/interfaces#c0a83c57f877d98096dde4bda1ec56a80f4a88eb"
 dependencies = [
  "arrayref",
  "ethereum-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ hashbrown = { version = "0.12.0", features = [
 ] }
 dashmap = "5.3"
 public-ip = "0.2.2"
+libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 e2p-fileflags = { git = "https://github.com/michaellass/e2p-fileflags" }

--- a/bin/akula.rs
+++ b/bin/akula.rs
@@ -2,6 +2,7 @@ use akula::{
     akula_tracing::{self, Component},
     binutil::AkulaDataDir,
     consensus::{engine_factory, Consensus, ForkChoiceMode},
+    execution::EvmMemory,
     kv::tables::CHAINDATA_TABLES,
     models::*,
     p2p::node::NodeBuilder,
@@ -459,6 +460,7 @@ fn main() -> anyhow::Result<()> {
                         exit_after_batch: opt.execution_exit_after_batch,
                         batch_until: None,
                         commit_every: None,
+                        mem: EvmMemory::new(),
                     },
                     false,
                 );

--- a/bin/akula.rs
+++ b/bin/akula.rs
@@ -34,8 +34,6 @@ use tokio::time::sleep;
 use tracing::*;
 use tracing_subscriber::prelude::*;
 
-const MIB: usize = 1 << 20;
-
 #[derive(Parser)]
 #[clap(name = "Akula", about = "Next-generation Ethereum implementation.")]
 pub struct Opt {
@@ -159,384 +157,370 @@ fn main() -> anyhow::Result<()> {
 
     akula_tracing::build_subscriber(Component::Core).init();
 
-    std::thread::Builder::new()
-        .stack_size(8 * MIB)
-        .spawn(move || {
-            let rt = tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .thread_stack_size(8 * MIB)
-                .build()?;
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_stack_size(8 * (1 << 20))
+        .build()?;
 
-            rt.block_on(async move {
-                info!("Starting Akula ({})", version_string());
+    rt.block_on(async move {
+        info!("Starting Akula ({})", version_string());
 
-                info!("Allocating EVM memory");
-                let mem = EvmMemory::new_with_size(opt.page_size);
+        info!("Allocating EVM memory");
+        let mem = EvmMemory::new_with_size(opt.page_size);
 
-                let mut bundled_chain_spec = false;
-                let chain_config = if let Some(chain) = opt.chain {
-                    bundled_chain_spec = true;
-                    Some(ChainSpec::load_builtin(&chain)?)
-                } else if let Some(path) = opt.chain_spec_file {
-                    Some(ChainSpec::load_from_file(path)?)
-                } else {
-                    None
-                };
+        let mut bundled_chain_spec = false;
+        let chain_config = if let Some(chain) = opt.chain {
+            bundled_chain_spec = true;
+            Some(ChainSpec::load_builtin(&chain)?)
+        } else if let Some(path) = opt.chain_spec_file {
+            Some(ChainSpec::load_from_file(path)?)
+        } else {
+            None
+        };
 
-                std::fs::create_dir_all(&opt.datadir.0)?;
-                let akula_chain_data_dir = opt.datadir.chain_data_dir();
-                let etl_temp_path = opt.datadir.etl_temp_dir();
-                let _ = std::fs::remove_dir_all(&etl_temp_path);
-                std::fs::create_dir_all(&etl_temp_path)?;
-                let etl_temp_dir = Arc::new(
-                    tempfile::tempdir_in(&etl_temp_path)
-                        .context("failed to create ETL temp dir")?,
-                );
-                let db = Arc::new(akula::kv::new_database(
-                    &CHAINDATA_TABLES,
-                    &akula_chain_data_dir,
-                )?);
+        std::fs::create_dir_all(&opt.datadir.0)?;
+        let akula_chain_data_dir = opt.datadir.chain_data_dir();
+        let etl_temp_path = opt.datadir.etl_temp_dir();
+        let _ = std::fs::remove_dir_all(&etl_temp_path);
+        std::fs::create_dir_all(&etl_temp_path)?;
+        let etl_temp_dir = Arc::new(
+            tempfile::tempdir_in(&etl_temp_path).context("failed to create ETL temp dir")?,
+        );
+        let db = Arc::new(akula::kv::new_database(
+            &CHAINDATA_TABLES,
+            &akula_chain_data_dir,
+        )?);
 
-                akula::database_version::migrate_database(&db)?;
+        akula::database_version::migrate_database(&db)?;
 
-                let chainspec = {
-                    let span = span!(Level::INFO, "", " Genesis initialization ");
-                    let _g = span.enter();
-                    let txn = db.begin_mutable()?;
-                    let (chainspec, initialized) = akula::genesis::initialize_genesis(
-                        &txn,
-                        &etl_temp_dir,
-                        bundled_chain_spec,
-                        chain_config,
-                    )?;
-                    if initialized {
-                        txn.commit()?;
-                    }
+        let chainspec = {
+            let span = span!(Level::INFO, "", " Genesis initialization ");
+            let _g = span.enter();
+            let txn = db.begin_mutable()?;
+            let (chainspec, initialized) = akula::genesis::initialize_genesis(
+                &txn,
+                &etl_temp_dir,
+                bundled_chain_spec,
+                chain_config,
+            )?;
+            if initialized {
+                txn.commit()?;
+            }
 
-                    chainspec
-                };
+            chainspec
+        };
 
-                info!("Current network: {}", chainspec.name);
+        info!("Current network: {}", chainspec.name);
 
-                let jwt_secret_path = opt
-                    .jwt_secret_path
-                    .map(|v| v.0)
-                    .unwrap_or_else(|| opt.datadir.0.join("jwt.hex"));
-                if let Ok(mut file) = OpenOptions::new()
-                    .write(true)
-                    .create_new(true)
-                    .open(jwt_secret_path)
-                {
-                    file.write_all(
-                        hex::encode(
-                            std::iter::repeat_with(rand::random)
-                                .take(32)
-                                .collect::<Vec<_>>(),
+        let jwt_secret_path = opt
+            .jwt_secret_path
+            .map(|v| v.0)
+            .unwrap_or_else(|| opt.datadir.0.join("jwt.hex"));
+        if let Ok(mut file) = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(jwt_secret_path)
+        {
+            file.write_all(
+                hex::encode(
+                    std::iter::repeat_with(rand::random)
+                        .take(32)
+                        .collect::<Vec<_>>(),
+                )
+                .as_bytes(),
+            )?;
+            file.flush()?;
+        }
+
+        let consensus: Arc<dyn Consensus> = engine_factory(
+            Some(db.clone()),
+            chainspec.clone(),
+            Some(opt.engine_listen_address),
+        )?
+        .into();
+
+        let network_id = chainspec.params.network_id;
+
+        let chain_config = ChainConfig::from(chainspec);
+
+        if !opt.no_rpc {
+            tokio::spawn({
+                let db = db.clone();
+                async move {
+                    let http_server = HttpServerBuilder::default()
+                        .build(&opt.rpc_listen_address)
+                        .await
+                        .unwrap();
+
+                    let websocket_server = WsServerBuilder::default()
+                        .build(&opt.websocket_listen_address)
+                        .await
+                        .unwrap();
+
+                    let mut api = Methods::new();
+
+                    let api_options = opt
+                        .enable_api
+                        .map(|v| {
+                            v.split(',')
+                                .into_iter()
+                                .map(|s| s.to_lowercase())
+                                .collect::<HashSet<String>>()
+                        })
+                        .unwrap_or_default();
+
+                    if api_options.is_empty() || api_options.contains("eth") {
+                        api.merge(
+                            EthApiServerImpl {
+                                db: db.clone(),
+                                call_gas_limit: 100_000_000,
+                            }
+                            .into_rpc(),
                         )
-                        .as_bytes(),
-                    )?;
-                    file.flush()?;
-                }
+                        .unwrap();
+                    }
 
-                let consensus: Arc<dyn Consensus> = engine_factory(
-                    Some(db.clone()),
-                    chainspec.clone(),
-                    Some(opt.engine_listen_address),
-                )?
-                .into();
-
-                let network_id = chainspec.params.network_id;
-
-                let chain_config = ChainConfig::from(chainspec);
-
-                if !opt.no_rpc {
-                    tokio::spawn({
-                        let db = db.clone();
-                        async move {
-                            let http_server = HttpServerBuilder::default()
-                                .build(&opt.rpc_listen_address)
-                                .await
-                                .unwrap();
-
-                            let websocket_server = WsServerBuilder::default()
-                                .build(&opt.websocket_listen_address)
-                                .await
-                                .unwrap();
-
-                            let mut api = Methods::new();
-
-                            let api_options = opt
-                                .enable_api
-                                .map(|v| {
-                                    v.split(',')
-                                        .into_iter()
-                                        .map(|s| s.to_lowercase())
-                                        .collect::<HashSet<String>>()
-                                })
-                                .unwrap_or_default();
-
-                            if api_options.is_empty() || api_options.contains("eth") {
-                                api.merge(
-                                    EthApiServerImpl {
-                                        db: db.clone(),
-                                        call_gas_limit: 100_000_000,
-                                    }
-                                    .into_rpc(),
-                                )
-                                .unwrap();
-                            }
-
-                            if api_options.is_empty() || api_options.contains("net") {
-                                api.merge(NetApiServerImpl { network_id }.into_rpc())
-                                    .unwrap();
-                            }
-
-                            if api_options.is_empty() || api_options.contains("erigon") {
-                                api.merge(ErigonApiServerImpl { db: db.clone() }.into_rpc())
-                                    .unwrap();
-                            }
-
-                            if api_options.is_empty() || api_options.contains("otterscan") {
-                                api.merge(OtterscanApiServerImpl { db: db.clone() }.into_rpc())
-                                    .unwrap();
-                            }
-
-                            if api_options.is_empty() || api_options.contains("parity") {
-                                api.merge(ParityApiServerImpl { db: db.clone() }.into_rpc())
-                                    .unwrap();
-                            }
-
-                            if api_options.is_empty() || api_options.contains("trace") {
-                                api.merge(
-                                    TraceApiServerImpl {
-                                        db: db.clone(),
-                                        call_gas_limit: 100_000_000,
-                                    }
-                                    .into_rpc(),
-                                )
-                                .unwrap();
-                            }
-
-                            if api_options.is_empty() || api_options.contains("web3") {
-                                api.merge(Web3ApiServerImpl.into_rpc()).unwrap();
-                            }
-
-                            let _http_server_handle = http_server.start(api.clone()).unwrap();
-                            info!("HTTP server listening on {}", opt.rpc_listen_address);
-
-                            let _websocket_server_handle = websocket_server.start(api).unwrap();
-                            info!(
-                                "WebSocket server listening on {}",
-                                opt.websocket_listen_address
-                            );
-
-                            pending::<()>().await
-                        }
-                    });
-
-                    tokio::spawn({
-                        let db = db.clone();
-                        async move {
-                            info!("Starting gRPC server on {}", opt.grpc_listen_address);
-                            let mut builder = tonic::transport::Server::builder();
-
-                            #[cfg(feature = "grpc-reflection")]
-                            builder.add_service(
-                                tonic_reflection::server::Builder::configure()
-                                    .register_encoded_file_descriptor_set(
-                                        ethereum_interfaces::FILE_DESCRIPTOR_SET,
-                                    )
-                                    .build()
-                                    .unwrap(),
-                            );
-
-                            builder.add_service(
-                                ethereum_interfaces::web3::debug_api_server::DebugApiServer::new(
-                                    DebugApiServerImpl {
-                                        db: db.clone(),
-                                    }
-                                )
-                            )
-                            .add_service(
-                                ethereum_interfaces::web3::trace_api_server::TraceApiServer::new(
-                                    TraceApiServerImpl {
-                                        db,
-                                        call_gas_limit: 100_000_000,
-                                    },
-                                ),
-                            )
-                            .serve(opt.grpc_listen_address)
-                            .await
+                    if api_options.is_empty() || api_options.contains("net") {
+                        api.merge(NetApiServerImpl { network_id }.into_rpc())
                             .unwrap();
-                        }
-                    });
-                }
-
-                let increment = opt.increment.or({
-                    if opt.prune {
-                        Some(BlockNumber(90_000))
-                    } else {
-                        None
                     }
-                });
 
-                // staged sync setup
-                let mut staged_sync = stagedsync::StagedSync::new();
-                staged_sync.set_min_progress_to_commit_after_stage(if opt.prune {
-                    u64::MAX
-                } else {
-                    1024
-                });
-                if opt.prune {
-                    staged_sync.set_pruning_interval(90_000);
-                }
-                staged_sync.set_max_block(opt.max_block);
-                staged_sync.start_with_unwind(opt.start_with_unwind);
-                staged_sync.set_exit_after_sync(opt.exit_after_sync);
+                    if api_options.is_empty() || api_options.contains("erigon") {
+                        api.merge(ErigonApiServerImpl { db: db.clone() }.into_rpc())
+                            .unwrap();
+                    }
 
-                if opt.delay_after_sync > 0 {
-                    staged_sync
-                        .set_delay_after_sync(Some(Duration::from_millis(opt.delay_after_sync)));
-                }
+                    if api_options.is_empty() || api_options.contains("otterscan") {
+                        api.merge(OtterscanApiServerImpl { db: db.clone() }.into_rpc())
+                            .unwrap();
+                    }
 
-                let sentries = if let Some(raw_str) = opt.sentry_api_addr {
-                    raw_str
-                        .split(',')
-                        .filter_map(|s| s.parse::<Uri>().ok())
-                        .collect::<Vec<_>>()
-                } else {
-                    let max_peers = opt.sentry_opts.max_peers;
-                    let sentry_api_addr = opt.sentry_opts.sentry_addr;
-                    let swarm = akula::sentry::run(
-                        opt.sentry_opts,
-                        opt.datadir,
-                        chain_config.chain_spec.p2p.clone(),
-                    )
-                    .await?;
+                    if api_options.is_empty() || api_options.contains("parity") {
+                        api.merge(ParityApiServerImpl { db: db.clone() }.into_rpc())
+                            .unwrap();
+                    }
 
-                    let current_stage = staged_sync.current_stage();
-
-                    tokio::spawn(async move {
-                        loop {
-                            if let Some(stage) = *current_stage.borrow() {
-                                if stage == HEADERS || stage == BODIES {
-                                    info!(
-                                        "P2P node peer info: {} active (+{} dialing) / {} max.",
-                                        swarm.connected_peers(),
-                                        swarm.dialing(),
-                                        max_peers
-                                    );
-                                }
+                    if api_options.is_empty() || api_options.contains("trace") {
+                        api.merge(
+                            TraceApiServerImpl {
+                                db: db.clone(),
+                                call_gas_limit: 100_000_000,
                             }
-
-                            sleep(Duration::from_secs(5)).await;
-                        }
-                    });
-
-                    vec![format!("http://{sentry_api_addr}").parse()?]
-                };
-
-                let mut builder = NodeBuilder::new(chain_config.clone()).set_stash(db.clone());
-                for sentry_api_addr in sentries {
-                    builder = builder.add_sentry(sentry_api_addr);
-                }
-
-                let node = Arc::new(builder.build()?);
-                let tip_discovery =
-                    !matches!(consensus.fork_choice_mode(), ForkChoiceMode::External(_));
-
-                tokio::spawn({
-                    let node = node.clone();
-                    async move {
-                        node.start_sync(tip_discovery).await.unwrap();
+                            .into_rpc(),
+                        )
+                        .unwrap();
                     }
-                });
 
-                staged_sync.push(
-                    HeaderDownload {
-                        node: node.clone(),
-                        consensus: consensus.clone(),
-                        max_block: opt.max_block.unwrap_or_else(|| u64::MAX.into()),
-                        increment,
-                    },
-                    false,
-                );
-                staged_sync.push(TotalGasIndex, false);
-                staged_sync.push(
-                    BlockHashes {
-                        temp_dir: etl_temp_dir.clone(),
-                    },
-                    false,
-                );
-                staged_sync.push(BodyDownload { node, consensus }, false);
-                staged_sync.push(TotalTxIndex, false);
-                staged_sync.push(
-                    SenderRecovery {
-                        batch_size: opt.sender_recovery_batch_size.try_into().unwrap(),
-                    },
-                    false,
-                );
-                staged_sync.push(
-                    Execution {
-                        max_block: opt.max_block,
-                        batch_size: opt.execution_batch_size.saturating_mul(1_000_000_000_u64),
-                        history_batch_size: opt
-                            .execution_history_batch_size
-                            .saturating_mul(1_000_000_000_u64),
-                        exit_after_batch: opt.execution_exit_after_batch,
-                        batch_until: None,
-                        commit_every: None,
-                        mem,
-                    },
-                    false,
-                );
-                if !opt.skip_commitment {
-                    staged_sync.push(HashState::new(etl_temp_dir.clone(), None), !opt.prune);
-                    staged_sync.push_with_unwind_priority(
-                        Interhashes::new(etl_temp_dir.clone(), None),
-                        !opt.prune,
-                        1,
+                    if api_options.is_empty() || api_options.contains("web3") {
+                        api.merge(Web3ApiServerImpl.into_rpc()).unwrap();
+                    }
+
+                    let _http_server_handle = http_server.start(api.clone()).unwrap();
+                    info!("HTTP server listening on {}", opt.rpc_listen_address);
+
+                    let _websocket_server_handle = websocket_server.start(api).unwrap();
+                    info!(
+                        "WebSocket server listening on {}",
+                        opt.websocket_listen_address
                     );
-                }
-                staged_sync.push(
-                    AccountHistoryIndex {
-                        temp_dir: etl_temp_dir.clone(),
-                        flush_interval: 50_000,
-                    },
-                    !opt.prune,
-                );
-                staged_sync.push(
-                    StorageHistoryIndex {
-                        temp_dir: etl_temp_dir.clone(),
-                        flush_interval: 50_000,
-                    },
-                    !opt.prune,
-                );
-                staged_sync.push(
-                    TxLookup {
-                        temp_dir: etl_temp_dir.clone(),
-                    },
-                    !opt.prune,
-                );
-                staged_sync.push(
-                    CallTraceIndex {
-                        temp_dir: etl_temp_dir.clone(),
-                        flush_interval: 50_000,
-                    },
-                    !opt.prune,
-                );
-                staged_sync.push(Finish, !opt.prune);
 
-                info!("Running staged sync");
-                staged_sync.run(&db).await?;
-
-                if opt.exit_after_sync {
-                    Ok(())
-                } else {
-                    pending().await
+                    pending::<()>().await
                 }
-            })
-        })?
-        .join()
-        .unwrap_or_else(|e| panic::resume_unwind(e))
+            });
+
+            tokio::spawn({
+                let db = db.clone();
+                async move {
+                    info!("Starting gRPC server on {}", opt.grpc_listen_address);
+                    let mut builder = tonic::transport::Server::builder();
+
+                    #[cfg(feature = "grpc-reflection")]
+                    builder.add_service(
+                        tonic_reflection::server::Builder::configure()
+                            .register_encoded_file_descriptor_set(
+                                ethereum_interfaces::FILE_DESCRIPTOR_SET,
+                            )
+                            .build()
+                            .unwrap(),
+                    );
+
+                    builder
+                        .add_service(
+                            ethereum_interfaces::web3::debug_api_server::DebugApiServer::new(
+                                DebugApiServerImpl { db: db.clone() },
+                            ),
+                        )
+                        .add_service(
+                            ethereum_interfaces::web3::trace_api_server::TraceApiServer::new(
+                                TraceApiServerImpl {
+                                    db,
+                                    call_gas_limit: 100_000_000,
+                                },
+                            ),
+                        )
+                        .serve(opt.grpc_listen_address)
+                        .await
+                        .unwrap();
+                }
+            });
+        }
+
+        let increment = opt.increment.or({
+            if opt.prune {
+                Some(BlockNumber(90_000))
+            } else {
+                None
+            }
+        });
+
+        // staged sync setup
+        let mut staged_sync = stagedsync::StagedSync::new();
+        staged_sync.set_min_progress_to_commit_after_stage(if opt.prune { u64::MAX } else { 1024 });
+        if opt.prune {
+            staged_sync.set_pruning_interval(90_000);
+        }
+        staged_sync.set_max_block(opt.max_block);
+        staged_sync.start_with_unwind(opt.start_with_unwind);
+        staged_sync.set_exit_after_sync(opt.exit_after_sync);
+
+        if opt.delay_after_sync > 0 {
+            staged_sync.set_delay_after_sync(Some(Duration::from_millis(opt.delay_after_sync)));
+        }
+
+        let sentries = if let Some(raw_str) = opt.sentry_api_addr {
+            raw_str
+                .split(',')
+                .filter_map(|s| s.parse::<Uri>().ok())
+                .collect::<Vec<_>>()
+        } else {
+            let max_peers = opt.sentry_opts.max_peers;
+            let sentry_api_addr = opt.sentry_opts.sentry_addr;
+            let swarm = akula::sentry::run(
+                opt.sentry_opts,
+                opt.datadir,
+                chain_config.chain_spec.p2p.clone(),
+            )
+            .await?;
+
+            let current_stage = staged_sync.current_stage();
+
+            tokio::spawn(async move {
+                loop {
+                    if let Some(stage) = *current_stage.borrow() {
+                        if stage == HEADERS || stage == BODIES {
+                            info!(
+                                "P2P node peer info: {} active (+{} dialing) / {} max.",
+                                swarm.connected_peers(),
+                                swarm.dialing(),
+                                max_peers
+                            );
+                        }
+                    }
+
+                    sleep(Duration::from_secs(5)).await;
+                }
+            });
+
+            vec![format!("http://{sentry_api_addr}").parse()?]
+        };
+
+        let mut builder = NodeBuilder::new(chain_config.clone()).set_stash(db.clone());
+        for sentry_api_addr in sentries {
+            builder = builder.add_sentry(sentry_api_addr);
+        }
+
+        let node = Arc::new(builder.build()?);
+        let tip_discovery = !matches!(consensus.fork_choice_mode(), ForkChoiceMode::External(_));
+
+        tokio::spawn({
+            let node = node.clone();
+            async move {
+                node.start_sync(tip_discovery).await.unwrap();
+            }
+        });
+
+        staged_sync.push(
+            HeaderDownload {
+                node: node.clone(),
+                consensus: consensus.clone(),
+                max_block: opt.max_block.unwrap_or_else(|| u64::MAX.into()),
+                increment,
+            },
+            false,
+        );
+        staged_sync.push(TotalGasIndex, false);
+        staged_sync.push(
+            BlockHashes {
+                temp_dir: etl_temp_dir.clone(),
+            },
+            false,
+        );
+        staged_sync.push(BodyDownload { node, consensus }, false);
+        staged_sync.push(TotalTxIndex, false);
+        staged_sync.push(
+            SenderRecovery {
+                batch_size: opt.sender_recovery_batch_size.try_into().unwrap(),
+            },
+            false,
+        );
+        staged_sync.push(
+            Execution {
+                max_block: opt.max_block,
+                batch_size: opt.execution_batch_size.saturating_mul(1_000_000_000_u64),
+                history_batch_size: opt
+                    .execution_history_batch_size
+                    .saturating_mul(1_000_000_000_u64),
+                exit_after_batch: opt.execution_exit_after_batch,
+                batch_until: None,
+                commit_every: None,
+                mem,
+            },
+            false,
+        );
+        if !opt.skip_commitment {
+            staged_sync.push(HashState::new(etl_temp_dir.clone(), None), !opt.prune);
+            staged_sync.push_with_unwind_priority(
+                Interhashes::new(etl_temp_dir.clone(), None),
+                !opt.prune,
+                1,
+            );
+        }
+        staged_sync.push(
+            AccountHistoryIndex {
+                temp_dir: etl_temp_dir.clone(),
+                flush_interval: 50_000,
+            },
+            !opt.prune,
+        );
+        staged_sync.push(
+            StorageHistoryIndex {
+                temp_dir: etl_temp_dir.clone(),
+                flush_interval: 50_000,
+            },
+            !opt.prune,
+        );
+        staged_sync.push(
+            TxLookup {
+                temp_dir: etl_temp_dir.clone(),
+            },
+            !opt.prune,
+        );
+        staged_sync.push(
+            CallTraceIndex {
+                temp_dir: etl_temp_dir.clone(),
+                flush_interval: 50_000,
+            },
+            !opt.prune,
+        );
+        staged_sync.push(Finish, !opt.prune);
+
+        info!("Running staged sync");
+        staged_sync.run(&db).await?;
+
+        if opt.exit_after_sync {
+            Ok(())
+        } else {
+            pending().await
+        }
+    })
 }

--- a/bin/akula.rs
+++ b/bin/akula.rs
@@ -2,7 +2,7 @@ use akula::{
     akula_tracing::{self, Component},
     binutil::AkulaDataDir,
     consensus::{engine_factory, Consensus, ForkChoiceMode},
-    execution::EvmMemory,
+    execution::{EvmMemory, PageSize},
     kv::tables::CHAINDATA_TABLES,
     models::*,
     p2p::node::NodeBuilder,
@@ -16,7 +16,7 @@ use akula::{
     version_string,
 };
 use anyhow::Context;
-use clap::Parser;
+use clap::{builder::TypedValueParser, Parser};
 use ethereum_jsonrpc::{
     ErigonApiServer, EthApiServer, NetApiServer, OtterscanApiServer, ParityApiServer,
     TraceApiServer, Web3ApiServer,
@@ -106,6 +106,18 @@ pub struct Opt {
     #[clap(long)]
     pub no_rpc: bool,
 
+    /// Select page size used by EVM.
+    ///
+    /// Using a non-default value requires huge page support
+    /// from OS and 1 GiB worth of huge pages to be available.
+    #[clap(
+        long,
+        default_value = "4KiB",
+        value_parser = clap::builder::PossibleValuesParser::new(["4KiB", "2MiB", "1GiB"])
+            .map(parse_page_size),
+    )]
+    pub page_size: PageSize,
+
     /// Enable API options
     #[clap(long)]
     pub enable_api: Option<String>,
@@ -131,6 +143,15 @@ pub struct Opt {
     pub jwt_secret_path: Option<ExpandedPathBuf>,
 }
 
+fn parse_page_size(s: String) -> PageSize {
+    match s.as_str() {
+        "4KiB" => PageSize::Page4KiB,
+        "2MiB" => PageSize::Page2MiB,
+        "1GiB" => PageSize::Page1GiB,
+        _ => panic!("Invalid page size"),
+    }
+}
+
 #[allow(unreachable_code)]
 fn main() -> anyhow::Result<()> {
     let opt: Opt = Opt::parse();
@@ -148,6 +169,9 @@ fn main() -> anyhow::Result<()> {
 
             rt.block_on(async move {
                 info!("Starting Akula ({})", version_string());
+
+                info!("Allocating EVM memory");
+                let mem = EvmMemory::new_with_size(opt.page_size);
 
                 let mut bundled_chain_spec = false;
                 let chain_config = if let Some(chain) = opt.chain {
@@ -462,7 +486,7 @@ fn main() -> anyhow::Result<()> {
                         exit_after_batch: opt.execution_exit_after_batch,
                         batch_until: None,
                         commit_every: None,
-                        mem: EvmMemory::new(),
+                        mem,
                     },
                     false,
                 );

--- a/bin/akula.rs
+++ b/bin/akula.rs
@@ -34,6 +34,8 @@ use tokio::time::sleep;
 use tracing::*;
 use tracing_subscriber::prelude::*;
 
+const MIB: usize = 1 << 20;
+
 #[derive(Parser)]
 #[clap(name = "Akula", about = "Next-generation Ethereum implementation.")]
 pub struct Opt {
@@ -137,11 +139,11 @@ fn main() -> anyhow::Result<()> {
     akula_tracing::build_subscriber(Component::Core).init();
 
     std::thread::Builder::new()
-        .stack_size(128 * 1024 * 1024)
+        .stack_size(8 * MIB)
         .spawn(move || {
             let rt = tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
-                .thread_stack_size(128 * 1024 * 1024)
+                .thread_stack_size(8 * MIB)
                 .build()?;
 
             rt.block_on(async move {

--- a/bin/consensus-tests.rs
+++ b/bin/consensus-tests.rs
@@ -909,7 +909,7 @@ async fn run() {
 fn main() {
     Builder::new_multi_thread()
         .enable_all()
-        .thread_stack_size(128 * 1024 * 1024)
+        .thread_stack_size(4 * (1 << 20))
         .build()
         .unwrap()
         .block_on(run());

--- a/src/consensus/blockchain.rs
+++ b/src/consensus/blockchain.rs
@@ -1,6 +1,8 @@
 use crate::{
     consensus::*,
-    execution::{analysis_cache::AnalysisCache, processor::ExecutionProcessor, tracer::NoopTracer},
+    execution::{
+        analysis_cache::AnalysisCache, processor::ExecutionProcessor, tracer::NoopTracer, EvmMemory,
+    },
     models::*,
     state::*,
 };
@@ -14,6 +16,7 @@ pub struct Blockchain<'state> {
     engine: Box<dyn Consensus>,
     bad_blocks: HashMap<H256, ValidationError>,
     receipts: Vec<Receipt>,
+    mem: EvmMemory,
 }
 
 impl<'state> Blockchain<'state> {
@@ -47,6 +50,7 @@ impl<'state> Blockchain<'state> {
             config,
             bad_blocks: Default::default(),
             receipts: Default::default(),
+            mem: EvmMemory::new(),
         })
     }
 
@@ -154,6 +158,7 @@ impl<'state> Blockchain<'state> {
             &block.header,
             &body,
             &block_spec,
+            &mut self.mem,
         );
 
         let _ = processor.execute_and_write_block()?;

--- a/src/execution/evm/benches/bench.rs
+++ b/src/execution/evm/benches/bench.rs
@@ -2,7 +2,7 @@ use akula::{
     execution::evm::{
         instructions::{instruction_table::get_instruction_table, PROPERTIES},
         util::{mocked_host::MockedHost, Bytecode},
-        AnalyzedCode, CallKind, InterpreterMessage, OpCode, Output, StatusCode,
+        AnalyzedCode, CallKind, EvmMemory, InterpreterMessage, OpCode, Output, StatusCode,
     },
     models::Revision,
 };
@@ -324,9 +324,15 @@ fn generate_code(params: &CodeParams) -> Bytecode {
 
 #[inline]
 fn execute(
-    (code, mut host, msg, rev): (AnalyzedCode, MockedHost, InterpreterMessage, Revision),
+    (code, mut host, msg, mut mem, rev): (
+        AnalyzedCode,
+        MockedHost,
+        InterpreterMessage,
+        EvmMemory,
+        Revision,
+    ),
 ) -> Output {
-    code.execute(&mut host, &msg, rev)
+    code.execute(&mut host, &msg, mem.get_origin(), rev)
 }
 
 fn synthetic_benchmarks(c: &mut Criterion) {
@@ -461,7 +467,13 @@ fn synthetic_benchmarks(c: &mut Criterion) {
 fn prepare(
     code: AnalyzedCode,
     input_data: Bytes,
-) -> (AnalyzedCode, MockedHost, InterpreterMessage, Revision) {
+) -> (
+    AnalyzedCode,
+    MockedHost,
+    InterpreterMessage,
+    EvmMemory,
+    Revision,
+) {
     get_instruction_table(Revision::Istanbul);
     (
         code,
@@ -478,6 +490,7 @@ fn prepare(
             input_data,
             value: U256::ZERO,
         },
+        EvmMemory::new(),
         Revision::Istanbul,
     )
 }
@@ -553,7 +566,7 @@ fn main_benchmarks(c: &mut Criterion) {
                 let analyzed_code = analyzed_code.clone();
                 let input_data = input_data.clone();
                 b.iter_batched(
-                    move || prepare(analyzed_code.clone(), input_data.clone()),
+                    || prepare(analyzed_code.clone(), input_data.clone()),
                     execute,
                     BatchSize::SmallInput,
                 )

--- a/src/execution/evm/host.rs
+++ b/src/execution/evm/host.rs
@@ -1,4 +1,4 @@
-use crate::execution::{evm::EvmStack, tracer::{NoopTracer, Tracer}};
+use crate::execution::{evm::EvmSubMemory, tracer::{NoopTracer, Tracer}};
 
 use super::{
     common::{InterpreterMessage, Output},
@@ -99,7 +99,7 @@ pub trait Host {
     /// Self-destruct account.
     fn selfdestruct(&mut self, address: Address, beneficiary: Address);
     /// Call to another account.
-    fn call(&mut self, msg: Call, stack: EvmStack) -> Output;
+    fn call(&mut self, msg: Call, mem: EvmSubMemory) -> Output;
     /// Retrieve transaction context.
     fn get_tx_context(&mut self) -> Result<TxContext, StatusCode>;
     /// Get block hash.

--- a/src/execution/evm/host.rs
+++ b/src/execution/evm/host.rs
@@ -1,4 +1,7 @@
-use crate::execution::{evm::EvmSubMemory, tracer::{NoopTracer, Tracer}};
+use crate::execution::{
+    evm::EvmSubMemory,
+    tracer::{NoopTracer, Tracer},
+};
 
 use super::{
     common::{InterpreterMessage, Output},

--- a/src/execution/evm/host.rs
+++ b/src/execution/evm/host.rs
@@ -1,4 +1,4 @@
-use crate::execution::tracer::{NoopTracer, Tracer};
+use crate::execution::{evm::EvmStack, tracer::{NoopTracer, Tracer}};
 
 use super::{
     common::{InterpreterMessage, Output},
@@ -99,7 +99,7 @@ pub trait Host {
     /// Self-destruct account.
     fn selfdestruct(&mut self, address: Address, beneficiary: Address);
     /// Call to another account.
-    fn call(&mut self, msg: Call) -> Output;
+    fn call(&mut self, msg: Call, stack: EvmStack) -> Output;
     /// Retrieve transaction context.
     fn get_tx_context(&mut self) -> Result<TxContext, StatusCode>;
     /// Get block hash.

--- a/src/execution/evm/instructions/arithmetic.rs
+++ b/src/execution/evm/instructions/arithmetic.rs
@@ -1,5 +1,8 @@
 use crate::{
-    execution::evm::{state::{EvmStack, ExecutionState}, StatusCode},
+    execution::evm::{
+        state::{EvmStack, ExecutionState},
+        StatusCode,
+    },
     models::*,
 };
 use ethereum_types::U512;

--- a/src/execution/evm/instructions/arithmetic.rs
+++ b/src/execution/evm/instructions/arithmetic.rs
@@ -126,9 +126,8 @@ fn log2floor(value: U256) -> u64 {
 
 #[inline]
 pub(crate) fn exp<const REVISION: Revision>(state: &mut ExecutionState) -> Result<(), StatusCode> {
-    let mut stack = state.mem.stack();
-    let mut base = stack.pop();
-    let mut power = stack.pop();
+    let mut base = state.stack().pop();
+    let mut power = state.stack().pop();
 
     if power > 0 {
         let factor = if REVISION >= Revision::Spurious {
@@ -155,7 +154,7 @@ pub(crate) fn exp<const REVISION: Revision>(state: &mut ExecutionState) -> Resul
         base = base.overflowing_mul(base).0;
     }
 
-    stack.push(v);
+    state.stack().push(v);
 
     Ok(())
 }

--- a/src/execution/evm/instructions/arithmetic.rs
+++ b/src/execution/evm/instructions/arithmetic.rs
@@ -126,8 +126,9 @@ fn log2floor(value: U256) -> u64 {
 
 #[inline]
 pub(crate) fn exp<const REVISION: Revision>(state: &mut ExecutionState) -> Result<(), StatusCode> {
-    let mut base = state.stack.pop();
-    let mut power = state.stack.pop();
+    let mut stack = state.mem.stack();
+    let mut base = stack.pop();
+    let mut power = stack.pop();
 
     if power > 0 {
         let factor = if REVISION >= Revision::Spurious {
@@ -154,7 +155,7 @@ pub(crate) fn exp<const REVISION: Revision>(state: &mut ExecutionState) -> Resul
         base = base.overflowing_mul(base).0;
     }
 
-    state.stack.push(v);
+    stack.push(v);
 
     Ok(())
 }

--- a/src/execution/evm/instructions/arithmetic.rs
+++ b/src/execution/evm/instructions/arithmetic.rs
@@ -1,5 +1,5 @@
 use crate::{
-    execution::evm::{state::*, StatusCode},
+    execution::evm::{state::{EvmStack, ExecutionState}, StatusCode},
     models::*,
 };
 use ethereum_types::U512;
@@ -7,35 +7,35 @@ use ethnum::U256;
 use i256::{i256_div, i256_mod};
 
 #[inline]
-pub(crate) fn add(stack: &mut Stack) {
+pub(crate) fn add(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.pop();
     stack.push(a.overflowing_add(b).0);
 }
 
 #[inline]
-pub(crate) fn mul(stack: &mut Stack) {
+pub(crate) fn mul(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.pop();
     stack.push(a.overflowing_mul(b).0);
 }
 
 #[inline]
-pub(crate) fn sub(stack: &mut Stack) {
+pub(crate) fn sub(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.pop();
     stack.push(a.overflowing_sub(b).0);
 }
 
 #[inline]
-pub(crate) fn div(stack: &mut Stack) {
+pub(crate) fn div(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
     *b = if *b == 0 { U256::ZERO } else { a / *b };
 }
 
 #[inline]
-pub(crate) fn sdiv(stack: &mut Stack) {
+pub(crate) fn sdiv(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.pop();
     let v = i256_div(a, b);
@@ -43,14 +43,14 @@ pub(crate) fn sdiv(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn modulo(stack: &mut Stack) {
+pub(crate) fn modulo(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
     *b = if *b == 0 { U256::ZERO } else { a % *b };
 }
 
 #[inline]
-pub(crate) fn smod(stack: &mut Stack) {
+pub(crate) fn smod(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
 
@@ -62,7 +62,7 @@ pub(crate) fn smod(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn addmod(stack: &mut Stack) {
+pub(crate) fn addmod(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.pop();
     let c = stack.pop();
@@ -84,7 +84,7 @@ pub(crate) fn addmod(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn mulmod(stack: &mut Stack) {
+pub(crate) fn mulmod(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.pop();
     let c = stack.pop();
@@ -160,7 +160,7 @@ pub(crate) fn exp<const REVISION: Revision>(state: &mut ExecutionState) -> Resul
 }
 
 #[inline]
-pub(crate) fn signextend(stack: &mut Stack) {
+pub(crate) fn signextend(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
 

--- a/src/execution/evm/instructions/bitwise.rs
+++ b/src/execution/evm/instructions/bitwise.rs
@@ -79,8 +79,8 @@ pub(crate) fn sar(stack: &mut EvmStack) {
 
 #[cfg(test)]
 mod tests {
-    use crate::execution::evm::state::EvmMemory;
     use super::*;
+    use crate::execution::evm::state::EvmMemory;
 
     #[test]
     fn test_instruction_byte() {

--- a/src/execution/evm/instructions/bitwise.rs
+++ b/src/execution/evm/instructions/bitwise.rs
@@ -1,9 +1,9 @@
-use crate::execution::evm::state::Stack;
+use crate::execution::evm::state::EvmStack;
 use ethnum::U256;
 use i256::{i256_sign, two_compl, Sign};
 
 #[inline]
-pub(crate) fn byte(stack: &mut Stack) {
+pub(crate) fn byte(stack: &mut EvmStack) {
     let i = stack.pop();
     let x = stack.get_mut(0);
 
@@ -25,7 +25,7 @@ pub(crate) fn byte(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn shl(stack: &mut Stack) {
+pub(crate) fn shl(stack: &mut EvmStack) {
     let shift = stack.pop();
     let value = stack.get_mut(0);
 
@@ -37,7 +37,7 @@ pub(crate) fn shl(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn shr(stack: &mut Stack) {
+pub(crate) fn shr(stack: &mut EvmStack) {
     let shift = stack.pop();
     let value = stack.get_mut(0);
 
@@ -49,7 +49,7 @@ pub(crate) fn shr(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn sar(stack: &mut Stack) {
+pub(crate) fn sar(stack: &mut EvmStack) {
     let shift = stack.pop();
     let mut value = stack.pop();
 
@@ -79,6 +79,7 @@ pub(crate) fn sar(stack: &mut Stack) {
 
 #[cfg(test)]
 mod tests {
+    use crate::execution::evm::state::EvmSuperStack;
     use super::*;
 
     #[test]
@@ -91,8 +92,9 @@ mod tests {
                 .unwrap(),
         );
 
+        let mut super_stack = EvmSuperStack::new();
         for i in 0u16..32 {
-            let mut stack = Stack::new();
+            let mut stack = super_stack.get_origin_stack();
             stack.push(value);
             stack.push(U256::from(i));
 
@@ -102,7 +104,7 @@ mod tests {
             assert_eq!(result, U256::from(5 * (i + 1)));
         }
 
-        let mut stack = Stack::new();
+        let mut stack = super_stack.get_origin_stack();
         stack.push(value);
         stack.push(U256::from(100u128));
 
@@ -110,7 +112,7 @@ mod tests {
         let result = stack.pop();
         assert_eq!(result, U256::ZERO);
 
-        let mut stack = Stack::new();
+        let mut stack = super_stack.get_origin_stack();
         stack.push(value);
         stack.push(U256::from_words(1, 0));
 

--- a/src/execution/evm/instructions/bitwise.rs
+++ b/src/execution/evm/instructions/bitwise.rs
@@ -105,7 +105,7 @@ mod tests {
             assert_eq!(result, U256::from(5 * (i + 1)));
         }
 
-        let mut mem = evm_mem.get_origin();
+        let mut mem = mem.next_submem();
         let mut stack = mem.stack();
         stack.push(value);
         stack.push(U256::from(100u128));
@@ -114,7 +114,7 @@ mod tests {
         let result = stack.pop();
         assert_eq!(result, U256::ZERO);
 
-        let mut mem = evm_mem.get_origin();
+        let mut mem = mem.next_submem();
         let mut stack = mem.stack();
         stack.push(value);
         stack.push(U256::from_words(1, 0));

--- a/src/execution/evm/instructions/bitwise.rs
+++ b/src/execution/evm/instructions/bitwise.rs
@@ -79,7 +79,7 @@ pub(crate) fn sar(stack: &mut EvmStack) {
 
 #[cfg(test)]
 mod tests {
-    use crate::execution::evm::state::EvmSuperStack;
+    use crate::execution::evm::state::EvmMemory;
     use super::*;
 
     #[test]
@@ -92,9 +92,10 @@ mod tests {
                 .unwrap(),
         );
 
-        let mut super_stack = EvmSuperStack::new();
+        let mut evm_mem = EvmMemory::new();
+        let mut mem = evm_mem.get_origin();
         for i in 0u16..32 {
-            let mut stack = super_stack.get_origin_stack();
+            let mut stack = mem.stack();
             stack.push(value);
             stack.push(U256::from(i));
 
@@ -104,7 +105,8 @@ mod tests {
             assert_eq!(result, U256::from(5 * (i + 1)));
         }
 
-        let mut stack = super_stack.get_origin_stack();
+        let mut mem = evm_mem.get_origin();
+        let mut stack = mem.stack();
         stack.push(value);
         stack.push(U256::from(100u128));
 
@@ -112,7 +114,8 @@ mod tests {
         let result = stack.pop();
         assert_eq!(result, U256::ZERO);
 
-        let mut stack = super_stack.get_origin_stack();
+        let mut mem = evm_mem.get_origin();
+        let mut stack = mem.stack();
         stack.push(value);
         stack.push(U256::from_words(1, 0));
 

--- a/src/execution/evm/instructions/boolean.rs
+++ b/src/execution/evm/instructions/boolean.rs
@@ -1,10 +1,10 @@
-use crate::execution::evm::state::*;
+use crate::execution::evm::state::EvmStack;
 use ethnum::U256;
 use i256::i256_cmp;
 use std::cmp::Ordering;
 
 #[inline]
-pub(crate) fn lt(stack: &mut Stack) {
+pub(crate) fn lt(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
 
@@ -12,7 +12,7 @@ pub(crate) fn lt(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn gt(stack: &mut Stack) {
+pub(crate) fn gt(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
 
@@ -20,7 +20,7 @@ pub(crate) fn gt(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn slt(stack: &mut Stack) {
+pub(crate) fn slt(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
 
@@ -32,7 +32,7 @@ pub(crate) fn slt(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn sgt(stack: &mut Stack) {
+pub(crate) fn sgt(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
 
@@ -44,7 +44,7 @@ pub(crate) fn sgt(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn eq(stack: &mut Stack) {
+pub(crate) fn eq(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
 
@@ -52,34 +52,34 @@ pub(crate) fn eq(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn iszero(stack: &mut Stack) {
+pub(crate) fn iszero(stack: &mut EvmStack) {
     let a = stack.get_mut(0);
     *a = if *a == 0 { U256::ONE } else { U256::ZERO }
 }
 
 #[inline]
-pub(crate) fn and(stack: &mut Stack) {
+pub(crate) fn and(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
     *b = a & *b;
 }
 
 #[inline]
-pub(crate) fn or(stack: &mut Stack) {
+pub(crate) fn or(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
     *b = a | *b;
 }
 
 #[inline]
-pub(crate) fn xor(stack: &mut Stack) {
+pub(crate) fn xor(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
     *b = a ^ *b;
 }
 
 #[inline]
-pub(crate) fn not(stack: &mut Stack) {
+pub(crate) fn not(stack: &mut EvmStack) {
     let v = stack.get_mut(0);
     *v = !*v;
 }

--- a/src/execution/evm/instructions/call.rs
+++ b/src/execution/evm/instructions/call.rs
@@ -135,7 +135,7 @@ pub(crate) fn do_call<
         if let Some(MemoryRegion { offset, size }) = output_region {
             let copy_size = min(size.get(), result.output_data.len());
             if copy_size > 0 {
-                state.mem.heap()[offset..offset + copy_size]
+                state.mem.heap()[offset..][..copy_size]
                     .copy_from_slice(&result.output_data[..copy_size]);
             }
         }
@@ -201,10 +201,9 @@ pub(crate) fn do_create<H: Host, const REVISION: Revision, const CREATE2: bool>(
 
             salt,
             initcode: if init_code_size != 0 {
-                state.mem.heap()[init_code_offset.as_usize()
-                    ..init_code_offset.as_usize() + init_code_size.as_usize()]
-                    .to_vec()
-                    .into()
+                let offset = init_code_offset.as_usize();
+                let size = init_code_size.as_usize();
+                state.mem.heap()[offset..][..size].to_vec().into()
             } else {
                 Bytes::new()
             },

--- a/src/execution/evm/instructions/call.rs
+++ b/src/execution/evm/instructions/call.rs
@@ -1,5 +1,7 @@
 use crate::{
-    execution::evm::{instructions::memory, state::MAX_CONTEXT_DEPTH, CallKind, ExecutionState, Host, StatusCode},
+    execution::evm::{
+        instructions::memory, state::MAX_CONTEXT_DEPTH, CallKind, ExecutionState, Host, StatusCode,
+    },
     models::Revision,
 };
 use bytes::Bytes;
@@ -80,7 +82,9 @@ pub(crate) fn do_call<
         },
         input_data: input_region
             .map(|MemoryRegion { offset, size }| {
-                state.mem.heap()[offset..offset + size.get()].to_vec().into()
+                state.mem.heap()[offset..offset + size.get()]
+                    .to_vec()
+                    .into()
             })
             .unwrap_or_default(),
     };

--- a/src/execution/evm/instructions/control.rs
+++ b/src/execution/evm/instructions/control.rs
@@ -19,10 +19,7 @@ pub(crate) fn ret(state: &mut ExecutionState) -> Result<(), StatusCode> {
 }
 
 #[inline]
-pub(crate) fn op_jump(
-    dst: U256,
-    jumpdest_map: &JumpdestMap,
-) -> Result<usize, StatusCode> {
+pub(crate) fn op_jump(dst: U256, jumpdest_map: &JumpdestMap) -> Result<usize, StatusCode> {
     if !jumpdest_map.contains(dst) {
         return Err(StatusCode::BadJumpDestination);
     }
@@ -53,6 +50,8 @@ pub(crate) fn calldataload(state: &mut ExecutionState) {
 
 #[inline]
 pub(crate) fn calldatasize(state: &mut ExecutionState) {
-    let res = u128::try_from(state.message.input_data.len()).unwrap().into();
+    let res = u128::try_from(state.message.input_data.len())
+        .unwrap()
+        .into();
     state.stack().push(res);
 }

--- a/src/execution/evm/instructions/control.rs
+++ b/src/execution/evm/instructions/control.rs
@@ -10,9 +10,9 @@ pub(crate) fn ret(state: &mut ExecutionState) -> Result<(), StatusCode> {
     if let Some(region) =
         super::memory::get_memory_region(state, offset, size).map_err(|_| StatusCode::OutOfGas)?
     {
-        state.output_data = state.mem.heap()[region.offset..region.offset + region.size.get()]
-            .to_vec()
-            .into();
+        let offset = region.offset;
+        let size = region.size.get();
+        state.output_data = state.mem.heap()[offset..][..size].to_vec().into();
     }
 
     Ok(())
@@ -37,26 +37,22 @@ pub(crate) fn calldataload(state: &mut ExecutionState) {
 
     let input_len = state.message.input_data.len();
 
-    stack.push({
-        if index > u128::try_from(input_len).unwrap() {
-            U256::ZERO
-        } else {
-            let index_usize = index.as_usize();
-            let end = core::cmp::min(index_usize + 32, input_len);
+    let res = if index > u128::try_from(input_len).unwrap() {
+        U256::ZERO
+    } else {
+        let index_usize = index.as_usize();
+        let end = core::cmp::min(index_usize + 32, input_len);
 
-            let mut data = [0; 32];
-            data[..end - index_usize].copy_from_slice(&state.message.input_data[index_usize..end]);
+        let mut data = [0; 32];
+        data[..end - index_usize].copy_from_slice(&state.message.input_data[index_usize..end]);
 
-            U256::from_be_bytes(data)
-        }
-    });
+        U256::from_be_bytes(data)
+    };
+    stack.push(res);
 }
 
 #[inline]
 pub(crate) fn calldatasize(state: &mut ExecutionState) {
-    state.mem.stack().push(
-        u128::try_from(state.message.input_data.len())
-            .unwrap()
-            .into(),
-    );
+    let res = u128::try_from(state.message.input_data.len()).unwrap().into();
+    state.stack().push(res);
 }

--- a/src/execution/evm/instructions/external.rs
+++ b/src/execution/evm/instructions/external.rs
@@ -152,8 +152,6 @@ pub(crate) fn do_log<H: Host, const NUM_TOPICS: usize>(
     state: &mut ExecutionState,
     host: &mut H,
 ) -> Result<(), StatusCode> {
-    use arrayvec::ArrayVec;
-
     if state.message.is_static {
         return Err(StatusCode::StaticModeViolation);
     }
@@ -172,10 +170,7 @@ pub(crate) fn do_log<H: Host, const NUM_TOPICS: usize>(
         }
     }
 
-    let mut topics = ArrayVec::<U256, 4>::new();
-    for _ in 0..NUM_TOPICS {
-        topics.push(state.stack.pop());
-    }
+    let topics = [(); NUM_TOPICS].map(|()| state.stack.pop());
 
     let data = if let Some(region) = region {
         &state.memory[region.offset..region.offset + region.size.get()]

--- a/src/execution/evm/instructions/memory.rs
+++ b/src/execution/evm/instructions/memory.rs
@@ -176,20 +176,18 @@ pub(crate) fn keccak256(state: &mut ExecutionState) -> Result<(), StatusCode> {
     let region = get_memory_region(state, index, size).map_err(|_| StatusCode::OutOfGas)?;
 
     let heap = state.mem.heap();
-    let hash = Keccak256::digest(
-        if let Some(region) = region {
-            let w = num_words(region.size.get());
-            let cost = w * 6;
-            state.gas_left -= cost;
-            if state.gas_left < 0 {
-                return Err(StatusCode::OutOfGas);
-            }
+    let hash = Keccak256::digest(if let Some(region) = region {
+        let w = num_words(region.size.get());
+        let cost = w * 6;
+        state.gas_left -= cost;
+        if state.gas_left < 0 {
+            return Err(StatusCode::OutOfGas);
+        }
 
-            &heap[region.offset..region.offset + region.size.get()]
-        } else {
-            &[]
-        },
-    );
+        &heap[region.offset..region.offset + region.size.get()]
+    } else {
+        &[]
+    });
     state.mem.stack().push(u256_from_slice(&hash));
 
     Ok(())

--- a/src/execution/evm/instructions/memory.rs
+++ b/src/execution/evm/instructions/memory.rs
@@ -191,7 +191,7 @@ pub(crate) fn keccak256(state: &mut ExecutionState) -> Result<(), StatusCode> {
 }
 
 #[inline]
-pub(crate) fn codesize(stack: &mut Stack, code: &[u8]) {
+pub(crate) fn codesize(stack: &mut EvmStack, code: &[u8]) {
     stack.push(u128::try_from(code.len()).unwrap().into())
 }
 

--- a/src/execution/evm/instructions/stack_manip.rs
+++ b/src/execution/evm/instructions/stack_manip.rs
@@ -1,34 +1,34 @@
-use crate::execution::evm::{common::*, state::*};
+use crate::execution::evm::{common::*, state::EvmStack};
 use arrayref::array_ref;
 use ethnum::U256;
 
 #[inline]
-pub(crate) fn push<const LEN: usize>(stack: &mut Stack, code: &[u8]) -> usize {
+pub(crate) fn push<const LEN: usize>(stack: &mut EvmStack, code: &[u8]) -> usize {
     stack.push(u256_from_slice(&code[..LEN]));
     LEN
 }
 
 #[inline]
-pub(crate) fn push1(stack: &mut Stack, v: u8) {
+pub(crate) fn push1(stack: &mut EvmStack, v: u8) {
     stack.push(v.into());
 }
 
 #[inline]
-pub(crate) fn push32(stack: &mut Stack, code: &[u8]) {
+pub(crate) fn push32(stack: &mut EvmStack, code: &[u8]) {
     stack.push(U256::from_be_bytes(*array_ref!(code, 0, 32)));
 }
 
 #[inline]
-pub(crate) fn dup<const HEIGHT: usize>(stack: &mut Stack) {
+pub(crate) fn dup<const HEIGHT: usize>(stack: &mut EvmStack) {
     stack.push(*stack.get(HEIGHT - 1));
 }
 
 #[inline]
-pub(crate) fn swap<const HEIGHT: usize>(stack: &mut Stack) {
+pub(crate) fn swap<const HEIGHT: usize>(stack: &mut EvmStack) {
     stack.swap_top(HEIGHT);
 }
 
 #[inline]
-pub(crate) fn pop(stack: &mut Stack) {
+pub(crate) fn pop(stack: &mut EvmStack) {
     stack.pop();
 }

--- a/src/execution/evm/instructions/stack_manip.rs
+++ b/src/execution/evm/instructions/stack_manip.rs
@@ -1,21 +1,17 @@
-use crate::execution::evm::{common::*, state::EvmStack};
+use crate::execution::evm::{common::*, state::EvmStack, AnalyzedCode};
 use arrayref::array_ref;
 use ethnum::U256;
 
-#[inline]
-pub(crate) fn push<const LEN: usize>(stack: &mut EvmStack, code: &[u8]) -> usize {
-    stack.push(u256_from_slice(&code[..LEN]));
+#[inline(always)]
+pub(crate) fn push<const LEN: usize>(stack: &mut EvmStack, s: &AnalyzedCode, pc: usize) -> usize {
+    let code = &s.padded_code()[pc + 1..];
+    match LEN {
+        1 => stack.push(code[0].into()),
+        2..=31 => stack.push(u256_from_slice(&code[..LEN])),
+        32 => stack.push(U256::from_be_bytes(*array_ref!(code, 0, 32))),
+        _ => unreachable!(),
+    }
     LEN
-}
-
-#[inline]
-pub(crate) fn push1(stack: &mut EvmStack, v: u8) {
-    stack.push(v.into());
-}
-
-#[inline]
-pub(crate) fn push32(stack: &mut EvmStack, code: &[u8]) {
-    stack.push(U256::from_be_bytes(*array_ref!(code, 0, 32)));
 }
 
 #[inline]

--- a/src/execution/evm/interpreter.rs
+++ b/src/execution/evm/interpreter.rs
@@ -19,7 +19,7 @@ fn check_requirements(
         return Err(StatusCode::OutOfGas);
     }
 
-    let stack_size = state.stack.len();
+    let stack_size = state.mem.stack().len();
     if stack_size == STACK_SIZE {
         if metrics.can_overflow_stack {
             return Err(StatusCode::StackOverflow);
@@ -94,13 +94,13 @@ impl AnalyzedCode {
         &self,
         host: &mut H,
         message: &InterpreterMessage,
-        stack: EvmStack,
+        mem: EvmSubMemory,
         revision: Revision,
     ) -> Output
     where
         H: Host,
     {
-        let mut state = ExecutionState::new(message, stack);
+        let mut state = ExecutionState::new(message, mem);
 
         macro_rules! execute_revisions {
             (
@@ -180,84 +180,85 @@ where
 
         check_requirements(metrics, state)?;
 
+        let stack = &mut state.mem.stack();
         match op {
             OpCode::STOP => {
                 break;
             }
             OpCode::ADD => {
-                arithmetic::add(&mut state.stack);
+                arithmetic::add(stack);
             }
             OpCode::MUL => {
-                arithmetic::mul(&mut state.stack);
+                arithmetic::mul(stack);
             }
             OpCode::SUB => {
-                arithmetic::sub(&mut state.stack);
+                arithmetic::sub(stack);
             }
             OpCode::DIV => {
-                arithmetic::div(&mut state.stack);
+                arithmetic::div(stack);
             }
             OpCode::SDIV => {
-                arithmetic::sdiv(&mut state.stack);
+                arithmetic::sdiv(stack);
             }
             OpCode::MOD => {
-                arithmetic::modulo(&mut state.stack);
+                arithmetic::modulo(stack);
             }
             OpCode::SMOD => {
-                arithmetic::smod(&mut state.stack);
+                arithmetic::smod(stack);
             }
             OpCode::ADDMOD => {
-                arithmetic::addmod(&mut state.stack);
+                arithmetic::addmod(stack);
             }
             OpCode::MULMOD => {
-                arithmetic::mulmod(&mut state.stack);
+                arithmetic::mulmod(stack);
             }
             OpCode::EXP => {
                 arithmetic::exp::<REVISION>(state)?;
             }
             OpCode::SIGNEXTEND => {
-                arithmetic::signextend(&mut state.stack);
+                arithmetic::signextend(stack);
             }
             OpCode::LT => {
-                boolean::lt(&mut state.stack);
+                boolean::lt(stack);
             }
             OpCode::GT => {
-                boolean::gt(&mut state.stack);
+                boolean::gt(stack);
             }
             OpCode::SLT => {
-                boolean::slt(&mut state.stack);
+                boolean::slt(stack);
             }
             OpCode::SGT => {
-                boolean::sgt(&mut state.stack);
+                boolean::sgt(stack);
             }
             OpCode::EQ => {
-                boolean::eq(&mut state.stack);
+                boolean::eq(stack);
             }
             OpCode::ISZERO => {
-                boolean::iszero(&mut state.stack);
+                boolean::iszero(stack);
             }
             OpCode::AND => {
-                boolean::and(&mut state.stack);
+                boolean::and(stack);
             }
             OpCode::OR => {
-                boolean::or(&mut state.stack);
+                boolean::or(stack);
             }
             OpCode::XOR => {
-                boolean::xor(&mut state.stack);
+                boolean::xor(stack);
             }
             OpCode::NOT => {
-                boolean::not(&mut state.stack);
+                boolean::not(stack);
             }
             OpCode::BYTE => {
-                bitwise::byte(&mut state.stack);
+                bitwise::byte(stack);
             }
             OpCode::SHL => {
-                bitwise::shl(&mut state.stack);
+                bitwise::shl(stack);
             }
             OpCode::SHR => {
-                bitwise::shr(&mut state.stack);
+                bitwise::shr(stack);
             }
             OpCode::SAR => {
-                bitwise::sar(&mut state.stack);
+                bitwise::sar(stack);
             }
 
             OpCode::KECCAK256 => {
@@ -285,7 +286,7 @@ where
                 memory::calldatacopy(state)?;
             }
             OpCode::CODESIZE => {
-                memory::codesize(&mut state.stack, &s.code[..]);
+                memory::codesize(stack, &s.code[..]);
             }
             OpCode::CODECOPY => {
                 memory::codecopy(state, &s.code[..])?;
@@ -308,47 +309,41 @@ where
             OpCode::BLOCKHASH => {
                 external::blockhash(state, host)?;
             }
-            OpCode::ORIGIN => state
-                .stack
+            OpCode::ORIGIN => stack
                 .push(address_to_u256(host.get_tx_context()?.tx_origin)),
-            OpCode::COINBASE => state
-                .stack
+            OpCode::COINBASE => stack
                 .push(address_to_u256(host.get_tx_context()?.block_coinbase)),
-            OpCode::GASPRICE => state.stack.push(host.get_tx_context()?.tx_gas_price),
-            OpCode::TIMESTAMP => state
-                .stack
+            OpCode::GASPRICE => stack.push(host.get_tx_context()?.tx_gas_price),
+            OpCode::TIMESTAMP => stack
                 .push(host.get_tx_context()?.block_timestamp.into()),
-            OpCode::NUMBER => state.stack.push(host.get_tx_context()?.block_number.into()),
-            OpCode::DIFFICULTY => state.stack.push(host.get_tx_context()?.block_difficulty),
-            OpCode::GASLIMIT => state
-                .stack
+            OpCode::NUMBER => stack.push(host.get_tx_context()?.block_number.into()),
+            OpCode::DIFFICULTY => stack.push(host.get_tx_context()?.block_difficulty),
+            OpCode::GASLIMIT => stack
                 .push(host.get_tx_context()?.block_gas_limit.into()),
-            OpCode::CHAINID => state.stack.push(host.get_tx_context()?.chain_id),
-            OpCode::BASEFEE => state.stack.push(host.get_tx_context()?.block_base_fee),
+            OpCode::CHAINID => stack.push(host.get_tx_context()?.chain_id),
+            OpCode::BASEFEE => stack.push(host.get_tx_context()?.block_base_fee),
             OpCode::SELFBALANCE => {
                 external::selfbalance(state, host);
             }
-            OpCode::POP => pop(&mut state.stack),
+            OpCode::POP => pop(stack),
             OpCode::MLOAD => memory::mload(state)?,
             OpCode::MSTORE => memory::mstore(state)?,
             OpCode::MSTORE8 => memory::mstore8(state)?,
             OpCode::JUMP => {
-                pc = op_jump(state, &s.jumpdest_map)?;
+                let dst = stack.pop();
+                pc = op_jump(dst, &s.jumpdest_map)?;
 
                 continue;
             }
             OpCode::JUMPI => {
-                if *state.stack.get(1) != 0 {
-                    pc = op_jump(state, &s.jumpdest_map)?;
-                    state.stack.pop();
-
+                let dst = stack.pop();
+                let b = stack.pop();
+                if b != 0 {
+                    pc = op_jump(dst, &s.jumpdest_map)?;
                     continue;
-                } else {
-                    state.stack.pop();
-                    state.stack.pop();
                 }
             }
-            OpCode::PC => state.stack.push(u128::try_from(pc).unwrap().into()),
+            OpCode::PC => stack.push(u128::try_from(pc).unwrap().into()),
             OpCode::MSIZE => memory::msize(state),
             OpCode::SLOAD => {
                 external::sload::<_, REVISION>(state, host)?;
@@ -356,82 +351,81 @@ where
             OpCode::SSTORE => {
                 external::sstore::<_, REVISION>(state, host)?;
             }
-            OpCode::GAS => state
-                .stack
+            OpCode::GAS => stack
                 .push(u128::try_from(state.gas_left).unwrap().into()),
             OpCode::JUMPDEST => {}
             OpCode::PUSH1 => {
-                push1(&mut state.stack, s.padded_code[pc + 1]);
+                push1(stack, s.padded_code[pc + 1]);
                 pc += 1;
             }
-            OpCode::PUSH2 => pc += push::<2>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH3 => pc += push::<3>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH4 => pc += push::<4>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH5 => pc += push::<5>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH6 => pc += push::<6>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH7 => pc += push::<7>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH8 => pc += push::<8>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH9 => pc += push::<9>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH10 => pc += push::<10>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH11 => pc += push::<11>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH12 => pc += push::<12>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH13 => pc += push::<13>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH14 => pc += push::<14>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH15 => pc += push::<15>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH16 => pc += push::<16>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH17 => pc += push::<17>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH18 => pc += push::<18>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH19 => pc += push::<19>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH20 => pc += push::<20>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH21 => pc += push::<21>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH22 => pc += push::<22>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH23 => pc += push::<23>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH24 => pc += push::<24>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH25 => pc += push::<25>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH26 => pc += push::<26>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH27 => pc += push::<27>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH28 => pc += push::<28>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH29 => pc += push::<29>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH30 => pc += push::<30>(&mut state.stack, &s.padded_code[pc + 1..]),
-            OpCode::PUSH31 => pc += push::<31>(&mut state.stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH2 => pc += push::<2>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH3 => pc += push::<3>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH4 => pc += push::<4>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH5 => pc += push::<5>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH6 => pc += push::<6>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH7 => pc += push::<7>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH8 => pc += push::<8>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH9 => pc += push::<9>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH10 => pc += push::<10>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH11 => pc += push::<11>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH12 => pc += push::<12>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH13 => pc += push::<13>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH14 => pc += push::<14>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH15 => pc += push::<15>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH16 => pc += push::<16>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH17 => pc += push::<17>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH18 => pc += push::<18>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH19 => pc += push::<19>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH20 => pc += push::<20>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH21 => pc += push::<21>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH22 => pc += push::<22>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH23 => pc += push::<23>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH24 => pc += push::<24>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH25 => pc += push::<25>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH26 => pc += push::<26>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH27 => pc += push::<27>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH28 => pc += push::<28>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH29 => pc += push::<29>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH30 => pc += push::<30>(stack, &s.padded_code[pc + 1..]),
+            OpCode::PUSH31 => pc += push::<31>(stack, &s.padded_code[pc + 1..]),
             OpCode::PUSH32 => {
-                push32(&mut state.stack, &s.padded_code[pc + 1..]);
+                push32(stack, &s.padded_code[pc + 1..]);
                 pc += 32;
             }
 
-            OpCode::DUP1 => dup::<1>(&mut state.stack),
-            OpCode::DUP2 => dup::<2>(&mut state.stack),
-            OpCode::DUP3 => dup::<3>(&mut state.stack),
-            OpCode::DUP4 => dup::<4>(&mut state.stack),
-            OpCode::DUP5 => dup::<5>(&mut state.stack),
-            OpCode::DUP6 => dup::<6>(&mut state.stack),
-            OpCode::DUP7 => dup::<7>(&mut state.stack),
-            OpCode::DUP8 => dup::<8>(&mut state.stack),
-            OpCode::DUP9 => dup::<9>(&mut state.stack),
-            OpCode::DUP10 => dup::<10>(&mut state.stack),
-            OpCode::DUP11 => dup::<11>(&mut state.stack),
-            OpCode::DUP12 => dup::<12>(&mut state.stack),
-            OpCode::DUP13 => dup::<13>(&mut state.stack),
-            OpCode::DUP14 => dup::<14>(&mut state.stack),
-            OpCode::DUP15 => dup::<15>(&mut state.stack),
-            OpCode::DUP16 => dup::<16>(&mut state.stack),
+            OpCode::DUP1 => dup::<1>(stack),
+            OpCode::DUP2 => dup::<2>(stack),
+            OpCode::DUP3 => dup::<3>(stack),
+            OpCode::DUP4 => dup::<4>(stack),
+            OpCode::DUP5 => dup::<5>(stack),
+            OpCode::DUP6 => dup::<6>(stack),
+            OpCode::DUP7 => dup::<7>(stack),
+            OpCode::DUP8 => dup::<8>(stack),
+            OpCode::DUP9 => dup::<9>(stack),
+            OpCode::DUP10 => dup::<10>(stack),
+            OpCode::DUP11 => dup::<11>(stack),
+            OpCode::DUP12 => dup::<12>(stack),
+            OpCode::DUP13 => dup::<13>(stack),
+            OpCode::DUP14 => dup::<14>(stack),
+            OpCode::DUP15 => dup::<15>(stack),
+            OpCode::DUP16 => dup::<16>(stack),
 
-            OpCode::SWAP1 => swap::<1>(&mut state.stack),
-            OpCode::SWAP2 => swap::<2>(&mut state.stack),
-            OpCode::SWAP3 => swap::<3>(&mut state.stack),
-            OpCode::SWAP4 => swap::<4>(&mut state.stack),
-            OpCode::SWAP5 => swap::<5>(&mut state.stack),
-            OpCode::SWAP6 => swap::<6>(&mut state.stack),
-            OpCode::SWAP7 => swap::<7>(&mut state.stack),
-            OpCode::SWAP8 => swap::<8>(&mut state.stack),
-            OpCode::SWAP9 => swap::<9>(&mut state.stack),
-            OpCode::SWAP10 => swap::<10>(&mut state.stack),
-            OpCode::SWAP11 => swap::<11>(&mut state.stack),
-            OpCode::SWAP12 => swap::<12>(&mut state.stack),
-            OpCode::SWAP13 => swap::<13>(&mut state.stack),
-            OpCode::SWAP14 => swap::<14>(&mut state.stack),
-            OpCode::SWAP15 => swap::<15>(&mut state.stack),
-            OpCode::SWAP16 => swap::<16>(&mut state.stack),
+            OpCode::SWAP1 => swap::<1>(stack),
+            OpCode::SWAP2 => swap::<2>(stack),
+            OpCode::SWAP3 => swap::<3>(stack),
+            OpCode::SWAP4 => swap::<4>(stack),
+            OpCode::SWAP5 => swap::<5>(stack),
+            OpCode::SWAP6 => swap::<6>(stack),
+            OpCode::SWAP7 => swap::<7>(stack),
+            OpCode::SWAP8 => swap::<8>(stack),
+            OpCode::SWAP9 => swap::<9>(stack),
+            OpCode::SWAP10 => swap::<10>(stack),
+            OpCode::SWAP11 => swap::<11>(stack),
+            OpCode::SWAP12 => swap::<12>(stack),
+            OpCode::SWAP13 => swap::<13>(stack),
+            OpCode::SWAP14 => swap::<14>(stack),
+            OpCode::SWAP15 => swap::<15>(stack),
+            OpCode::SWAP16 => swap::<16>(stack),
 
             OpCode::LOG0 => external::do_log::<_, 0>(state, host)?,
             OpCode::LOG1 => external::do_log::<_, 1>(state, host)?,

--- a/src/execution/evm/interpreter.rs
+++ b/src/execution/evm/interpreter.rs
@@ -67,9 +67,7 @@ impl AnalyzedCode {
                     jumpdest_map[i] = true;
                     1
                 }
-                PUSH1..=PUSH32 => {
-                    (opcode - PUSH1 + 2) as usize
-                }
+                PUSH1..=PUSH32 => (opcode - PUSH1 + 2) as usize,
                 _ => 1,
             }
         }
@@ -121,10 +119,22 @@ impl AnalyzedCode {
         }
 
         let res = execute_revisions!(
-            host.trace_instructions(), revision, self, &mut state, host,
-            Frontier, Homestead, Tangerine, Spurious, Byzantium,
-            Constantinople, Petersburg, Istanbul, Berlin, London,
-            Paris,  
+            host.trace_instructions(),
+            revision,
+            self,
+            &mut state,
+            host,
+            Frontier,
+            Homestead,
+            Tangerine,
+            Spurious,
+            Byzantium,
+            Constantinople,
+            Petersburg,
+            Istanbul,
+            Berlin,
+            London,
+            Paris,
         );
 
         match res {

--- a/src/execution/evm/mod.rs
+++ b/src/execution/evm/mod.rs
@@ -5,7 +5,7 @@ pub use common::{
 pub use host::Host;
 pub use interpreter::AnalyzedCode;
 pub use opcode::OpCode;
-pub use state::{ExecutionState, Stack};
+pub use state::{ExecutionState, EvmStack, EvmSuperStack};
 
 /// Maximum allowed EVM bytecode size.
 pub const MAX_CODE_SIZE: usize = 0x6000;

--- a/src/execution/evm/mod.rs
+++ b/src/execution/evm/mod.rs
@@ -5,7 +5,7 @@ pub use common::{
 pub use host::Host;
 pub use interpreter::AnalyzedCode;
 pub use opcode::OpCode;
-pub use state::{ExecutionState, EvmStack, EvmMemory, EvmSubMemory};
+pub use state::{EvmMemory, EvmStack, EvmSubMemory, ExecutionState};
 
 /// Maximum allowed EVM bytecode size.
 pub const MAX_CODE_SIZE: usize = 0x6000;

--- a/src/execution/evm/mod.rs
+++ b/src/execution/evm/mod.rs
@@ -5,7 +5,7 @@ pub use common::{
 pub use host::Host;
 pub use interpreter::AnalyzedCode;
 pub use opcode::OpCode;
-pub use state::{ExecutionState, EvmStack, EvmSuperStack};
+pub use state::{ExecutionState, EvmStack, EvmMemory, EvmSubMemory};
 
 /// Maximum allowed EVM bytecode size.
 pub const MAX_CODE_SIZE: usize = 0x6000;

--- a/src/execution/evm/mod.rs
+++ b/src/execution/evm/mod.rs
@@ -5,7 +5,7 @@ pub use common::{
 pub use host::Host;
 pub use interpreter::AnalyzedCode;
 pub use opcode::OpCode;
-pub use state::{EvmMemory, EvmStack, EvmSubMemory, ExecutionState};
+pub use state::{EvmMemory, EvmStack, EvmSubMemory, ExecutionState, PageSize};
 
 /// Maximum allowed EVM bytecode size.
 pub const MAX_CODE_SIZE: usize = 0x6000;

--- a/src/execution/evm/state.rs
+++ b/src/execution/evm/state.rs
@@ -47,7 +47,7 @@ impl EvmMemory {
         }
     }
 
-    pub fn get_origin<'b>(&'b mut self) -> EvmSubMemory<'b> {
+    pub fn get_origin(&mut self) -> EvmSubMemory {
         let p = unsafe { self.p.add(SUPER_STACK_SIZE_BYTES).cast() };
         EvmSubMemory {
             stack_head: p,
@@ -71,6 +71,12 @@ impl Drop for EvmMemory {
     }
 }
 
+impl Default for EvmMemory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Note that stack grows down, while heap grows up, i.e. the following
 /// conditions MUST be always true:
 /// - `stack_base` >= `stack_head`
@@ -85,7 +91,7 @@ pub struct EvmSubMemory<'a> {
 
 impl<'a> EvmSubMemory<'a> {
     #[inline(always)]
-    pub fn next_submem<'b>(&'b mut self) -> EvmSubMemory<'b> {
+    pub fn next_submem(&mut self) -> Self {
         let stack_ptr = self.stack_head;
         let heap_ptr = self.heap_head;
         Self {

--- a/src/execution/evm/state.rs
+++ b/src/execution/evm/state.rs
@@ -21,6 +21,7 @@ const SUPER_STACK_SIZE_BYTES: usize = mem::size_of::<U256>() * SUPER_STACK_SIZE;
 /// allocated memory will be smaller.
 const TOTAL_MEM_SIZE: usize = 8 * (1 << 30);
 
+#[derive(Debug)]
 pub struct EvmMemory {
     p: *mut libc::c_void,
 }

--- a/src/execution/evm/state.rs
+++ b/src/execution/evm/state.rs
@@ -22,14 +22,14 @@ const SUPER_STACK_SIZE_BYTES: usize = mem::size_of::<U256>() * SUPER_STACK_SIZE;
 ///
 /// Currently transaction can use only 30M gas. Memory grow cost
 /// is computed as:
-/// ```
+/// ```ignore
 /// memory_size_word = (memory_byte_size + 31) / 32
 /// memory_cost = (memory_size_word ** 2) / 512 + (3 * memory_size_word)
 /// ```
 ///
 /// Thus max memory which can be allocated by one contract can be
 /// computed as:
-/// ```
+/// ```ignore
 /// memory_byte_size = 8192 * (sqrt(9 + available_gas / 128) - 3)
 /// ```
 /// Meaning that by using 30M gas one contract can allocate at most

--- a/src/execution/evm/state.rs
+++ b/src/execution/evm/state.rs
@@ -27,7 +27,7 @@ pub struct EvmMemory {
 }
 
 impl EvmMemory {
-    #[inline]
+    #[inline(always)]
     pub fn new() -> Self {
         unsafe {
             // TODO: add MAP_HUGETLB for huge tables
@@ -48,6 +48,7 @@ impl EvmMemory {
         }
     }
 
+    #[inline(always)]
     pub fn get_origin(&mut self) -> EvmSubMemory {
         let p = unsafe { self.p.add(SUPER_STACK_SIZE_BYTES).cast() };
         EvmSubMemory {
@@ -61,6 +62,7 @@ impl EvmMemory {
 }
 
 impl Drop for EvmMemory {
+    #[inline(always)]
     fn drop(&mut self) {
         unsafe {
             let res = libc::munmap(self.p.cast(), TOTAL_MEM_SIZE);
@@ -73,6 +75,7 @@ impl Drop for EvmMemory {
 }
 
 impl Default for EvmMemory {
+    #[inline(always)]
     fn default() -> Self {
         Self::new()
     }
@@ -109,10 +112,12 @@ impl<'a> EvmSubMemory<'a> {
         }
     }
 
+    #[inline(always)]
     pub fn stack<'b>(&'b mut self) -> EvmStack<'a, 'b> {
         EvmStack { mem: self }
     }
 
+    #[inline(always)]
     pub fn heap<'b>(&'b mut self) -> EvmHeap<'a, 'b> {
         EvmHeap { mem: self }
     }
@@ -193,7 +198,7 @@ impl<'a, 'b> EvmHeap<'a, 'b> {
         unsafe { self.mem.heap_head.offset_from(self.mem.heap_base) as usize }
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn grow(&mut self, size: usize) {
         let old_size = self.size();
         if size > old_size {
@@ -208,12 +213,14 @@ impl<'a, 'b> EvmHeap<'a, 'b> {
 impl<'a, 'b> core::ops::Deref for EvmHeap<'a, 'b> {
     type Target = [u8];
 
+    #[inline(always)]
     fn deref(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(self.mem.heap_base, self.size()) }
     }
 }
 
 impl<'a, 'b> core::ops::DerefMut for EvmHeap<'a, 'b> {
+    #[inline(always)]
     fn deref_mut(&mut self) -> &mut [u8] {
         unsafe { slice::from_raw_parts_mut(self.mem.heap_base, self.size()) }
     }
@@ -234,6 +241,7 @@ pub struct ExecutionState<'a> {
 }
 
 impl<'a> ExecutionState<'a> {
+    #[inline(always)]
     pub fn new(message: &'a InterpreterMessage, mem: EvmSubMemory<'a>) -> Self {
         Self {
             gas_left: message.gas,
@@ -244,19 +252,23 @@ impl<'a> ExecutionState<'a> {
         }
     }
 
+    #[inline(always)]
     pub fn stack<'b>(&'b mut self) -> EvmStack<'a, 'b> {
         self.mem.stack()
     }
 
+    #[inline(always)]
     pub fn heap<'b>(&'b mut self) -> EvmHeap<'a, 'b> {
         self.mem.heap()
     }
 
+    #[inline(always)]
     pub fn clone_stack_to_vec(&self) -> Vec<U256> {
         let len = unsafe { self.mem.stack_base.offset_from(self.mem.stack_head) as usize };
         unsafe { slice::from_raw_parts(self.mem.stack_head, len).to_vec() }
     }
 
+    #[inline(always)]
     pub fn heap_size(&self) -> usize {
         unsafe { self.mem.heap_head.offset_from(self.mem.heap_base) as usize }
     }

--- a/src/execution/evm/state.rs
+++ b/src/execution/evm/state.rs
@@ -187,10 +187,12 @@ impl<'a, 'b> EvmHeap<'a, 'b> {
 
     #[inline]
     pub fn grow(&mut self, size: usize) {
-        let head = &mut self.mem.heap_head;
-        let new_head = unsafe { self.mem.heap_base.add(size) };
-        if new_head > *head {
-            *head = new_head;
+        let old_size = self.size();
+        if size > old_size {
+            unsafe {
+                ptr::write_bytes(self.mem.heap_head, 0, size - old_size);
+                self.mem.heap_head = self.mem.heap_base.add(size);
+            }
         }
     }
 }

--- a/src/execution/evm/state.rs
+++ b/src/execution/evm/state.rs
@@ -32,8 +32,7 @@ impl EvmMemory {
             // TODO: add MAP_HUGETLB for huge tables
             let flags = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_NORESERVE;
             let mmap_res = libc::mmap(
-                // ptr::null_mut(),
-                0x0000_1000_0000_0000 as *mut _,
+                ptr::null_mut(),
                 TOTAL_MEM_SIZE,
                 libc::PROT_READ | libc::PROT_WRITE,
                 flags,

--- a/src/execution/evm/state.rs
+++ b/src/execution/evm/state.rs
@@ -1,8 +1,8 @@
-use super::{common::InterpreterMessage};
+use super::common::InterpreterMessage;
 use bytes::Bytes;
+use core::{marker::PhantomData, mem, ptr, slice};
 use ethnum::U256;
 use getset::{Getters, MutGetters};
-use core::{ptr, mem, slice, marker::PhantomData};
 use std::io;
 
 /// Size of EVM stack in U256s
@@ -80,7 +80,7 @@ pub struct EvmSubMemory<'a> {
     stack_base: *mut U256,
     heap_head: *mut u8,
     heap_base: *mut u8,
-    origin: PhantomData<&'a mut ()>,  
+    origin: PhantomData<&'a mut ()>,
 }
 
 impl<'a> EvmSubMemory<'a> {
@@ -98,15 +98,11 @@ impl<'a> EvmSubMemory<'a> {
     }
 
     pub fn stack<'b>(&'b mut self) -> EvmStack<'a, 'b> {
-        EvmStack {
-            mem: self,
-        }
+        EvmStack { mem: self }
     }
 
     pub fn heap<'b>(&'b mut self) -> EvmHeap<'a, 'b> {
-        EvmHeap {
-            mem: self,
-        }
+        EvmHeap { mem: self }
     }
 }
 
@@ -174,7 +170,7 @@ impl<'a, 'b> EvmStack<'a, 'b> {
 const PAGE_SIZE: usize = 4 * 1024;
 
 pub struct EvmHeap<'a, 'b> {
-    mem: &'b mut EvmSubMemory<'a>, 
+    mem: &'b mut EvmSubMemory<'a>,
 }
 
 impl<'a, 'b> EvmHeap<'a, 'b> {
@@ -201,17 +197,13 @@ impl<'a, 'b> core::ops::Deref for EvmHeap<'a, 'b> {
     type Target = [u8];
 
     fn deref(&self) -> &[u8] {
-        unsafe {
-            slice::from_raw_parts(self.mem.heap_base, self.size())
-        }
+        unsafe { slice::from_raw_parts(self.mem.heap_base, self.size()) }
     }
 }
 
 impl<'a, 'b> core::ops::DerefMut for EvmHeap<'a, 'b> {
     fn deref_mut(&mut self) -> &mut [u8] {
-        unsafe {
-            slice::from_raw_parts_mut(self.mem.heap_base, self.size())
-        }
+        unsafe { slice::from_raw_parts_mut(self.mem.heap_base, self.size()) }
     }
 }
 
@@ -250,9 +242,7 @@ impl<'a> ExecutionState<'a> {
 
     pub fn clone_stack_to_vec(&self) -> Vec<U256> {
         let len = unsafe { self.mem.stack_base.offset_from(self.mem.stack_head) as usize };
-        unsafe {
-            slice::from_raw_parts(self.mem.stack_head, len).to_vec()
-        }
+        unsafe { slice::from_raw_parts(self.mem.stack_head, len).to_vec() }
     }
 
     pub fn heap_size(&self) -> usize {

--- a/src/execution/evm/state.rs
+++ b/src/execution/evm/state.rs
@@ -1,9 +1,8 @@
 use super::{common::InterpreterMessage};
-use bytes::{Bytes, BytesMut};
-use derive_more::{Deref, DerefMut};
+use bytes::Bytes;
 use ethnum::U256;
 use getset::{Getters, MutGetters};
-use core::{ptr, mem};
+use core::{ptr, mem, slice, marker::PhantomData};
 use std::io;
 
 /// Size of EVM stack in U256s
@@ -13,21 +12,29 @@ const STACK_SIZE_BYTES: usize = mem::size_of::<U256>() * STACK_SIZE;
 
 pub(crate) const MAX_CONTEXT_DEPTH: usize = 1024;
 
-const SUPER_STACK_SIZE_BYTES: usize = STACK_SIZE_BYTES * MAX_CONTEXT_DEPTH;
+const SUPER_STACK_SIZE: usize = STACK_SIZE * MAX_CONTEXT_DEPTH;
+const SUPER_STACK_SIZE_BYTES: usize = mem::size_of::<U256>() * SUPER_STACK_SIZE;
 
-pub struct EvmSuperStack {
-    p: *mut [U256; SUPER_STACK_SIZE_BYTES],
+/// Total memory size allocated for EVM.
+///
+/// Note that allocated pages get populated lazily, i.e. physically
+/// allocated memory will be smaller.
+const TOTAL_MEM_SIZE: usize = 8 * (1 << 30);
+
+pub struct EvmMemory {
+    p: *mut libc::c_void,
 }
 
-impl EvmSuperStack {
+impl EvmMemory {
     #[inline]
     pub fn new() -> Self {
         unsafe {
             // TODO: add MAP_HUGETLB for huge tables
-            let flags = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS;
+            let flags = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_NORESERVE;
             let mmap_res = libc::mmap(
-                ptr::null_mut(),
-                SUPER_STACK_SIZE_BYTES,
+                // ptr::null_mut(),
+                0x0000_1000_0000_0000 as *mut _,
+                TOTAL_MEM_SIZE,
                 libc::PROT_READ | libc::PROT_WRITE,
                 flags,
                 -1,
@@ -37,24 +44,27 @@ impl EvmSuperStack {
                 let err = io::Error::last_os_error();
                 panic!("Failed to allocate memory for EVM stack: {err}");
             }
-            Self { p: mmap_res.cast() }
+            Self { p: mmap_res }
         }
     }
 
-    pub fn get_origin_stack(&mut self) -> EvmStack {
-        let p = unsafe { self.p.add(1).cast() };
-        EvmStack {
-            head: p,
-            base: p,
-            origin: self,
+    pub fn get_origin<'b>(&'b mut self) -> EvmSubMemory<'b> {
+        let p = unsafe { self.p.add(SUPER_STACK_SIZE_BYTES).cast() };
+        EvmSubMemory {
+            stack_head: p,
+            stack_base: p,
+            heap_head: p.cast(),
+            heap_base: p.cast(),
+            origin: PhantomData,
         }
     }
 }
 
-impl Drop for EvmSuperStack {
+impl Drop for EvmMemory {
     fn drop(&mut self) {
+        println!("Super stack drop: {:?}", self.p);
         unsafe {
-            let res = libc::munmap(self.p.cast(), SUPER_STACK_SIZE_BYTES);
+            let res = libc::munmap(self.p.cast(), TOTAL_MEM_SIZE);
             if res != 0 {
                 let err = io::Error::last_os_error();
                 panic!("Failed to deallocate stack memory: {err}")
@@ -63,43 +73,72 @@ impl Drop for EvmSuperStack {
     }
 }
 
-
-/// EVM stack.
-//#[derive(Clone, Debug, Default, Serialize)]
-pub struct EvmStack<'a> {
-    head: *mut U256,
-    /// Pointer to memory of [U256; STACK_SIZE]
-    base: *mut U256,
-    origin: &'a mut EvmSuperStack,
+/// Note that stack grows down, while heap grows up, i.e. the following
+/// conditions MUST be always true:
+/// - `stack_base` >= `stack_head`
+/// - `heap_base` <= `heap_head`
+pub struct EvmSubMemory<'a> {
+    stack_head: *mut U256,
+    stack_base: *mut U256,
+    heap_head: *mut u8,
+    heap_base: *mut u8,
+    origin: PhantomData<&'a mut ()>,  
 }
 
-impl<'a> EvmStack<'a> {
+impl<'a> EvmSubMemory<'a> {
     #[inline(always)]
-    pub fn next_substack<'b>(&'b mut self) -> EvmStack<'b> {
-        let p = unsafe { self.head.sub(16) };
-        EvmStack {
-            head: p,
-            base: p,
+    pub fn next_submem<'b>(&'b mut self) -> EvmSubMemory<'b> {
+        let stack_ptr = self.stack_head;
+        let heap_ptr = self.heap_head;
+        println!("next submem: {stack_ptr:?} {heap_ptr:?}");
+        Self {
+            stack_head: stack_ptr,
+            stack_base: stack_ptr,
+            heap_head: heap_ptr,
+            heap_base: heap_ptr,
             origin: self.origin,
         }
     }
 
+    pub fn stack<'b>(&'b mut self) -> EvmStack<'a, 'b> {
+        EvmStack {
+            mem: self,
+        }
+    }
+
+    pub fn heap<'b>(&'b mut self) -> EvmHeap<'a, 'b> {
+        EvmHeap {
+            mem: self,
+        }
+    }
+}
+
+pub struct EvmStack<'a, 'b> {
+    mem: &'b mut EvmSubMemory<'a>,
+}
+
+impl<'a, 'b> EvmStack<'a, 'b> {
     #[inline(always)]
     pub fn get(&self, pos: usize) -> &U256 {
+        println!("Get: {pos:?}", );
         debug_assert!(pos < self.len());
-        unsafe { &*self.head.add(pos) }
+        unsafe { &*self.mem.stack_head.add(pos) }
     }
 
     #[inline(always)]
     pub fn get_mut(&mut self, pos: usize) -> &mut U256 {
+        println!("Get mut: {pos:?}", );
         debug_assert!(pos < self.len());
-        unsafe { &mut *self.head.add(pos) }
+        unsafe { &mut *self.mem.stack_head.add(pos) }
     }
 
+    /// Get size of stack in `U256`s.
     #[inline(always)]
     pub fn len(&self) -> usize {
         // TODO: use sub_ptr on stabilization
-        unsafe { self.base.offset_from(self.head) as usize }
+        let len = unsafe { self.mem.stack_base.offset_from(self.mem.stack_head) as usize };
+        println!("Len: {len:?}");
+        len
     }
 
     #[inline(always)]
@@ -110,93 +149,123 @@ impl<'a> EvmStack<'a> {
     #[inline(always)]
     pub fn push(&mut self, v: U256) {
         debug_assert!(self.len() < STACK_SIZE);
+        let head = &mut self.mem.stack_head;
         unsafe {
-            self.head = self.head.sub(1);
-            ptr::write(self.head, v);
+            *head = head.sub(1);
+            ptr::write(*head, v);
         }
     }
 
     #[inline(always)]
     pub fn pop(&mut self) -> U256 {
+        println!("pop {:?}", self.len());
         debug_assert_ne!(self.len(), 0);
+        let head = &mut self.mem.stack_head;
         unsafe {
-            let val = ptr::read(self.head);
-            self.head = self.head.add(1);
+            let val = ptr::read(*head);
+            *head = head.add(1);
             val
         }
     }
 
     #[inline(always)]
     pub fn swap_top(&mut self, pos: usize) {
+        println!("swap_top");
         debug_assert_ne!(pos, 0);
         debug_assert!(pos < self.len());
+        let head = self.mem.stack_head;
         unsafe {
-            ptr::swap_nonoverlapping(self.head, self.head.add(pos), 1);
-        }
-    }
-
-    #[inline(always)]
-    pub fn clone_to_vec(&self) -> Vec<U256> {
-        unsafe {
-            core::slice::from_raw_parts(self.head, self.len()).to_vec()
+            ptr::swap_nonoverlapping(head, head.add(pos), 1);
         }
     }
 }
 
 const PAGE_SIZE: usize = 4 * 1024;
 
-#[derive(Clone, Debug, Deref, DerefMut)]
-pub struct Memory(BytesMut);
+pub struct EvmHeap<'a, 'b> {
+    mem: &'b mut EvmSubMemory<'a>, 
+}
 
-impl Memory {
-    #[inline]
-    pub fn new() -> Self {
-        Self(BytesMut::with_capacity(PAGE_SIZE))
+impl<'a, 'b> EvmHeap<'a, 'b> {
+    /// Get size of stack in `u8`s.
+    #[inline(always)]
+    fn size(&self) -> usize {
+        // TODO: use sub_ptr on stabilization
+        let len = unsafe { self.mem.heap_head.offset_from(self.mem.heap_base) as usize };
+        println!("Heap len: {len:?}");
+        len
     }
 
     #[inline]
     pub fn grow(&mut self, size: usize) {
-        let cap = self.0.capacity();
-        if size > cap {
-            let required_pages = (size + PAGE_SIZE - 1) / PAGE_SIZE;
-            self.0.reserve((PAGE_SIZE * required_pages) - self.0.len());
+        let head = &mut self.mem.heap_head;
+        let new_head = unsafe { self.mem.heap_base.add(size) };
+        if new_head > *head {
+            *head = new_head;
         }
-        self.0.resize(size, 0);
     }
 }
 
-impl Default for Memory {
-    fn default() -> Self {
-        Self::new()
+impl<'a, 'b> core::ops::Deref for EvmHeap<'a, 'b> {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        unsafe {
+            slice::from_raw_parts(self.mem.heap_base, self.size())
+        }
+    }
+}
+
+impl<'a, 'b> core::ops::DerefMut for EvmHeap<'a, 'b> {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        unsafe {
+            slice::from_raw_parts_mut(self.mem.heap_base, self.size())
+        }
     }
 }
 
 /// EVM execution state.
 // #[derive(Clone, Debug, Getters, MutGetters)]
 #[derive(Getters, MutGetters)]
-pub struct ExecutionState<'m> {
+pub struct ExecutionState<'a> {
     #[getset(get = "pub", get_mut = "pub")]
     pub(crate) gas_left: i64,
     #[getset(get = "pub", get_mut = "pub")]
-    pub(crate) stack: EvmStack<'m>,
-    #[getset(get = "pub", get_mut = "pub")]
-    pub(crate) memory: Memory,
-    pub(crate) message: &'m InterpreterMessage,
+    pub(crate) mem: EvmSubMemory<'a>,
+    pub(crate) message: &'a InterpreterMessage,
     #[getset(get = "pub", get_mut = "pub")]
     pub(crate) return_data: Bytes,
     pub(crate) output_data: Bytes,
 }
 
-impl<'m> ExecutionState<'m> {
-    pub fn new(message: &'m InterpreterMessage, stack: EvmStack<'m>) -> Self {
+impl<'a> ExecutionState<'a> {
+    pub fn new(message: &'a InterpreterMessage, mem: EvmSubMemory<'a>) -> Self {
         Self {
             gas_left: message.gas,
-            stack,
-            memory: Memory::new(),
+            mem,
             message,
             return_data: Default::default(),
             output_data: Bytes::new(),
         }
+    }
+
+    pub fn stack<'b>(&'b mut self) -> EvmStack<'a, 'b> {
+        self.mem.stack()
+    }
+
+    pub fn heap<'b>(&'b mut self) -> EvmHeap<'a, 'b> {
+        self.mem.heap()
+    }
+
+    pub fn clone_stack_to_vec(&self) -> Vec<U256> {
+        let len = unsafe { self.mem.stack_base.offset_from(self.mem.stack_head) as usize };
+        unsafe {
+            slice::from_raw_parts(self.mem.stack_head, len).to_vec()
+        }
+    }
+
+    pub fn heap_size(&self) -> usize {
+        unsafe { self.mem.heap_head.offset_from(self.mem.heap_base) as usize }
     }
 }
 
@@ -206,8 +275,9 @@ mod tests {
 
     #[test]
     fn stack() {
-        let mut super_stack = EvmSuperStack::new();
-        let mut stack = super_stack.get_origin_stack();
+        let mut evm_mem = EvmMemory::new();
+        let mut mem = evm_mem.get_origin();
+        let mut stack = mem.stack();
 
         let items: [u128; 4] = [0xde, 0xad, 0xbe, 0xef];
 
@@ -225,9 +295,15 @@ mod tests {
 
     #[test]
     fn grow() {
-        let mut mem = Memory::new();
-        mem.grow(PAGE_SIZE * 2 + 1);
-        assert_eq!(mem.len(), PAGE_SIZE * 2 + 1);
-        assert_eq!(mem.capacity(), PAGE_SIZE * 3);
+        const LEN: usize = 10_000;
+        let mut evm_mem = EvmMemory::new();
+        let mut mem = evm_mem.get_origin();
+        let mut heap = mem.heap();
+        heap.grow(LEN);
+        for val in heap.iter_mut() {
+            *val = 42;
+        }
+        assert!(heap.iter().all(|val| *val == 42));
+        assert_eq!(heap.len(), LEN);
     }
 }

--- a/src/execution/evm/state.rs
+++ b/src/execution/evm/state.rs
@@ -61,7 +61,6 @@ impl EvmMemory {
 
 impl Drop for EvmMemory {
     fn drop(&mut self) {
-        println!("Super stack drop: {:?}", self.p);
         unsafe {
             let res = libc::munmap(self.p.cast(), TOTAL_MEM_SIZE);
             if res != 0 {
@@ -89,7 +88,6 @@ impl<'a> EvmSubMemory<'a> {
     pub fn next_submem<'b>(&'b mut self) -> EvmSubMemory<'b> {
         let stack_ptr = self.stack_head;
         let heap_ptr = self.heap_head;
-        println!("next submem: {stack_ptr:?} {heap_ptr:?}");
         Self {
             stack_head: stack_ptr,
             stack_base: stack_ptr,
@@ -119,14 +117,12 @@ pub struct EvmStack<'a, 'b> {
 impl<'a, 'b> EvmStack<'a, 'b> {
     #[inline(always)]
     pub fn get(&self, pos: usize) -> &U256 {
-        println!("Get: {pos:?}", );
         debug_assert!(pos < self.len());
         unsafe { &*self.mem.stack_head.add(pos) }
     }
 
     #[inline(always)]
     pub fn get_mut(&mut self, pos: usize) -> &mut U256 {
-        println!("Get mut: {pos:?}", );
         debug_assert!(pos < self.len());
         unsafe { &mut *self.mem.stack_head.add(pos) }
     }
@@ -135,9 +131,7 @@ impl<'a, 'b> EvmStack<'a, 'b> {
     #[inline(always)]
     pub fn len(&self) -> usize {
         // TODO: use sub_ptr on stabilization
-        let len = unsafe { self.mem.stack_base.offset_from(self.mem.stack_head) as usize };
-        println!("Len: {len:?}");
-        len
+        unsafe { self.mem.stack_base.offset_from(self.mem.stack_head) as usize }
     }
 
     #[inline(always)]
@@ -157,7 +151,6 @@ impl<'a, 'b> EvmStack<'a, 'b> {
 
     #[inline(always)]
     pub fn pop(&mut self) -> U256 {
-        println!("pop {:?}", self.len());
         debug_assert_ne!(self.len(), 0);
         let head = &mut self.mem.stack_head;
         unsafe {
@@ -169,7 +162,6 @@ impl<'a, 'b> EvmStack<'a, 'b> {
 
     #[inline(always)]
     pub fn swap_top(&mut self, pos: usize) {
-        println!("swap_top");
         debug_assert_ne!(pos, 0);
         debug_assert!(pos < self.len());
         let head = self.mem.stack_head;
@@ -190,9 +182,7 @@ impl<'a, 'b> EvmHeap<'a, 'b> {
     #[inline(always)]
     fn size(&self) -> usize {
         // TODO: use sub_ptr on stabilization
-        let len = unsafe { self.mem.heap_head.offset_from(self.mem.heap_base) as usize };
-        println!("Heap len: {len:?}");
-        len
+        unsafe { self.mem.heap_head.offset_from(self.mem.heap_base) as usize }
     }
 
     #[inline]

--- a/src/execution/evm/state.rs
+++ b/src/execution/evm/state.rs
@@ -78,6 +78,11 @@ impl Default for EvmMemory {
     }
 }
 
+// SAFETY: `EvmMemory` owns the mapped memory (similarly to `Box`),
+// so it's safe to implement `Send` and `Sync` for it
+unsafe impl Send for EvmMemory {}
+unsafe impl Sync for EvmMemory {}
+
 /// Note that stack grows down, while heap grows up, i.e. the following
 /// conditions MUST be always true:
 /// - `stack_base` >= `stack_head`

--- a/src/execution/evm/util/mocked_host.rs
+++ b/src/execution/evm/util/mocked_host.rs
@@ -227,7 +227,7 @@ impl Host for MockedHost {
         });
     }
 
-    fn call(&mut self, msg: Call) -> Output {
+    fn call(&mut self, msg: Call, _stack: EvmStack) -> Output {
         let msg = match msg {
             Call::Call(message) => message.clone(),
             Call::Create(message) => message.clone().into(),

--- a/src/execution/evm/util/mocked_host.rs
+++ b/src/execution/evm/util/mocked_host.rs
@@ -227,7 +227,7 @@ impl Host for MockedHost {
         });
     }
 
-    fn call(&mut self, msg: Call, _stack: EvmStack) -> Output {
+    fn call(&mut self, msg: Call, _stack: EvmSubMemory) -> Output {
         let msg = match msg {
             Call::Call(message) => message.clone(),
             Call::Create(message) => message.clone().into(),

--- a/src/execution/evm/util/tester.rs
+++ b/src/execution/evm/util/tester.rs
@@ -24,10 +24,10 @@ fn exec(
     }
     let code = AnalyzedCode::analyze(&code);
 
-    let mut super_stack = EvmSuperStack::new();
-    let stack = super_stack.get_origin_stack();
+    let mut evm_mem = EvmMemory::new();
+    let mem = evm_mem.get_origin();
 
-    code.execute(host, &message, stack, revision)
+    code.execute(host, &message, mem, revision)
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/execution/evm/util/tester.rs
+++ b/src/execution/evm/util/tester.rs
@@ -24,7 +24,10 @@ fn exec(
     }
     let code = AnalyzedCode::analyze(&code);
 
-    code.execute(host, &message, revision)
+    let mut super_stack = EvmSuperStack::new();
+    let stack = super_stack.get_origin_stack();
+
+    code.execute(host, &message, stack, revision)
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/execution/evmglue.rs
+++ b/src/execution/evmglue.rs
@@ -52,6 +52,7 @@ pub fn execute<'db, 'tracer, 'analysis, B: HeaderReader + StateReader>(
     sender: Address,
     beneficiary: Address,
     gas: u64,
+    evm_mem: &mut EvmMemory,
 ) -> anyhow::Result<CallResult> {
     let mut evm = Evm {
         header,
@@ -64,7 +65,6 @@ pub fn execute<'db, 'tracer, 'analysis, B: HeaderReader + StateReader>(
         beneficiary,
     };
 
-    let mut evm_mem = EvmMemory::new();
     let submem = evm_mem.get_origin();
 
     let res = if let TransactionAction::Call(to) = message.action() {
@@ -664,6 +664,7 @@ mod tests {
         let mut tracer = NoopTracer;
         let beneficiary = header.beneficiary;
         let header = BlockHeader::new(header.clone(), EMPTY_LIST_HASH, EMPTY_ROOT);
+        let mut mem = EvmMemory::new();
         super::execute(
             state,
             &mut tracer,
@@ -674,6 +675,7 @@ mod tests {
             sender,
             beneficiary,
             gas,
+            &mut mem,
         )
         .unwrap()
     }

--- a/src/execution/evmglue.rs
+++ b/src/execution/evmglue.rs
@@ -809,7 +809,7 @@ mod tests {
     #[test]
     fn maximum_call_depth() {
         std::thread::Builder::new()
-            .stack_size(16 * (1 << 20))
+            .stack_size(64 * (1 << 20))
             .spawn(move || {
                 let header = PartialHeader {
                     number: 1_431_916.into(),

--- a/src/execution/evmglue.rs
+++ b/src/execution/evmglue.rs
@@ -347,7 +347,7 @@ where
         msg: &InterpreterMessage,
         code: &[u8],
         code_hash: Option<&H256>,
-        stack: EvmSubMemory,
+        mem: EvmSubMemory,
     ) -> anyhow::Result<Output> {
         let analysis = if let Some(code_hash) = code_hash {
             if let Some(cache) = self.analysis_cache.get(code_hash).cloned() {
@@ -363,7 +363,7 @@ where
 
         let revision = self.block_spec.revision;
 
-        let output = analysis.execute(self, msg, stack, revision);
+        let output = analysis.execute(self, msg, mem, revision);
 
         self.tracer.capture_end(
             msg.depth.try_into().unwrap(),
@@ -802,7 +802,7 @@ mod tests {
     #[test]
     fn maximum_call_depth() {
         std::thread::Builder::new()
-            .stack_size(128 * 1024 * 1024)
+            .stack_size(16 * (1 << 20))
             .spawn(move || {
                 let header = PartialHeader {
                     number: 1_431_916.into(),

--- a/src/execution/evmglue.rs
+++ b/src/execution/evmglue.rs
@@ -8,7 +8,8 @@ use crate::{
     chain::protocol_param::{fee, param},
     crypto::keccak256,
     execution::evm::{
-        host::*, AnalyzedCode, CallKind, CreateMessage, EvmSubMemory, EvmMemory, InterpreterMessage, Output, StatusCode,
+        host::*, AnalyzedCode, CallKind, CreateMessage, EvmMemory, EvmSubMemory,
+        InterpreterMessage, Output, StatusCode,
     },
     h256_to_u256,
     models::*,
@@ -67,27 +68,33 @@ pub fn execute<'db, 'tracer, 'analysis, B: HeaderReader + StateReader>(
     let submem = evm_mem.get_origin();
 
     let res = if let TransactionAction::Call(to) = message.action() {
-        evm.call(&InterpreterMessage {
-            kind: CallKind::Call,
-            is_static: false,
-            depth: 0,
-            sender,
-            input_data: message.input().clone(),
-            value: message.value(),
-            gas: gas as i64,
-            real_sender: sender,
-            recipient: to,
-            code_address: to,
-        }, submem)?
+        evm.call(
+            &InterpreterMessage {
+                kind: CallKind::Call,
+                is_static: false,
+                depth: 0,
+                sender,
+                input_data: message.input().clone(),
+                value: message.value(),
+                gas: gas as i64,
+                real_sender: sender,
+                recipient: to,
+                code_address: to,
+            },
+            submem,
+        )?
     } else {
-        evm.create(&CreateMessage {
-            depth: 0,
-            gas: gas as i64,
-            sender,
-            initcode: message.input().clone(),
-            endowment: message.value(),
-            salt: None,
-        }, submem)?
+        evm.create(
+            &CreateMessage {
+                depth: 0,
+                gas: gas as i64,
+                sender,
+                initcode: message.input().clone(),
+                endowment: message.value(),
+                salt: None,
+            },
+            submem,
+        )?
     };
 
     Ok(CallResult {

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -13,7 +13,7 @@ pub mod precompiled;
 pub mod processor;
 pub mod tracer;
 
-pub use evm::EvmMemory;
+pub use evm::{EvmMemory, PageSize};
 
 pub fn execute_block<S: State>(
     state: &mut S,

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -13,11 +13,14 @@ pub mod precompiled;
 pub mod processor;
 pub mod tracer;
 
+pub use evm::EvmMemory;
+
 pub fn execute_block<S: State>(
     state: &mut S,
     config: &ChainSpec,
     header: &BlockHeader,
     block: &BlockBodyWithSenders,
+    mem: &mut EvmMemory,
 ) -> Result<Vec<Receipt>, DuoError> {
     let mut analysis_cache = AnalysisCache::default();
     let mut engine = consensus::engine_factory(None, config.clone(), None)?;
@@ -32,6 +35,7 @@ pub fn execute_block<S: State>(
         header,
         block,
         &config,
+        mem,
     )
     .execute_and_write_block()
 }
@@ -133,6 +137,7 @@ mod tests {
         let tx = (t)(TransactionAction::Create, deployment_code.into(), 0, 0);
 
         let mut state = InMemoryState::default();
+        let mut mem = EvmMemory::new();
         let sender_account = Account {
             balance: ETHER.into(),
             ..Default::default()
@@ -151,6 +156,7 @@ mod tests {
                 transactions: vec![tx],
                 ommers: vec![],
             },
+            &mut mem,
         )
         .unwrap();
 
@@ -202,6 +208,7 @@ mod tests {
                 transactions: vec![tx],
                 ommers: vec![],
             },
+            &mut mem,
         )
         .unwrap();
 

--- a/src/execution/tracer/eip3155_tracer.rs
+++ b/src/execution/tracer/eip3155_tracer.rs
@@ -4,8 +4,8 @@ use crate::{
     models::*,
 };
 use bytes::Bytes;
-use serde::Serialize;
 use ethnum::U256;
+use serde::Serialize;
 
 #[derive(Serialize)]
 struct ExecutionStart {

--- a/src/execution/tracer/eip3155_tracer.rs
+++ b/src/execution/tracer/eip3155_tracer.rs
@@ -1,10 +1,11 @@
 use super::*;
 use crate::{
-    execution::evm::{ExecutionState, OpCode, Output, Stack, StatusCode},
+    execution::evm::{ExecutionState, OpCode, Output, StatusCode},
     models::*,
 };
 use bytes::Bytes;
 use serde::Serialize;
+use ethnum::U256;
 
 #[derive(Serialize)]
 struct ExecutionStart {
@@ -21,7 +22,7 @@ pub(crate) struct InstructionStart {
     pub op: u8,
     pub op_name: &'static str,
     pub gas: u64,
-    pub stack: Stack,
+    pub stack: Vec<U256>,
     pub memory_size: usize,
 }
 
@@ -70,7 +71,7 @@ impl Tracer for StdoutTracer {
                 op: op.0,
                 op_name: op.name(),
                 gas: env.gas_left as u64,
-                stack: env.stack.clone(),
+                stack: env.stack.clone_to_vec(),
                 memory_size: env.memory.len()
             })
             .unwrap()

--- a/src/execution/tracer/eip3155_tracer.rs
+++ b/src/execution/tracer/eip3155_tracer.rs
@@ -71,8 +71,8 @@ impl Tracer for StdoutTracer {
                 op: op.0,
                 op_name: op.name(),
                 gas: env.gas_left as u64,
-                stack: env.stack.clone_to_vec(),
-                memory_size: env.memory.len()
+                stack: env.clone_stack_to_vec(),
+                memory_size: env.heap_size(),
             })
             .unwrap()
         )

--- a/src/rpc/eth.rs
+++ b/src/rpc/eth.rs
@@ -4,6 +4,7 @@ use crate::{
     consensus::engine_factory,
     execution::{
         analysis_cache::AnalysisCache, evmglue, processor::ExecutionProcessor, tracer::NoopTracer,
+        EvmMemory,
     },
     kv::{mdbx::*, tables, MdbxWithDirHandle},
     models::*,
@@ -143,6 +144,7 @@ where
                         }
                     };
 
+                    let mut mem = EvmMemory::new();
                     for block_number in block_range {
                         let block_number = BlockNumber(block_number);
                         let block_hash =
@@ -186,6 +188,7 @@ where
                             &header,
                             &block_body,
                             &block_execution_spec,
+                            &mut mem,
                         );
 
                         let receipts = processor.execute_block_no_post_validation()?;
@@ -283,6 +286,8 @@ where
             let mut tracer = NoopTracer;
 
             let beneficiary = engine_factory(None, chain_spec, None)?.get_beneficiary(&header);
+            // TODO: check if we can reuse EvmMemory
+            let mut mem = EvmMemory::new();
             Ok(evmglue::execute(
                 &mut state,
                 &mut tracer,
@@ -293,6 +298,7 @@ where
                 sender,
                 beneficiary,
                 message.gas_limit(),
+                &mut mem,
             )?
             .output_data
             .into())
@@ -340,6 +346,8 @@ where
             let gas_limit = header.gas_limit;
 
             let beneficiary = engine_factory(None, chain_spec, None)?.get_beneficiary(&header);
+            // TODO: check if we can reuse EvmMemory
+            let mut mem = EvmMemory::new();
             Ok(U64::from(
                 gas_limit as i64
                     - evmglue::execute(
@@ -352,6 +360,7 @@ where
                         sender,
                         beneficiary,
                         gas_limit,
+                        &mut mem,
                     )?
                     .gas_left,
             ))
@@ -641,6 +650,8 @@ where
                 let mut engine = engine_factory(None, chain_spec, None)?;
                 let mut analysis_cache = AnalysisCache::default();
                 let mut tracer = NoopTracer;
+                // TODO: check if we can reuse EvmMemory
+                let mut mem = EvmMemory::new();
 
                 let mut processor = ExecutionProcessor::new(
                     &mut buffer,
@@ -650,6 +661,7 @@ where
                     &header,
                     &block_body,
                     &block_execution_spec,
+                    &mut mem,
                 );
 
                 let transaction_index = chain::block_body::read_without_senders(&txn, block_hash, block_number)?.ok_or_else(|| format_err!("where's block body"))?.transactions

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -13,6 +13,7 @@ pub mod helpers {
         consensus::{engine_factory, DuoError},
         execution::{
             analysis_cache::AnalysisCache, processor::ExecutionProcessor, tracer::NoopTracer,
+            EvmMemory,
         },
         kv::{mdbx::*, tables},
         models::*,
@@ -300,6 +301,8 @@ pub mod helpers {
         let mut analysis_cache = AnalysisCache::default();
         let mut tracer = NoopTracer;
 
+        // TODO: check if we can reuse EvmMemory
+        let mut mem = EvmMemory::new();
         let mut processor = ExecutionProcessor::new(
             &mut buffer,
             &mut tracer,
@@ -308,6 +311,7 @@ pub mod helpers {
             &header,
             &block_body,
             &block_execution_spec,
+            &mut mem,
         );
 
         processor

--- a/src/rpc/otterscan.rs
+++ b/src/rpc/otterscan.rs
@@ -6,6 +6,7 @@ use crate::{
         analysis_cache::AnalysisCache,
         processor::{execute_transaction, ExecutionProcessor},
         tracer::{CallKind, MessageKind, NoopTracer, Tracer},
+        EvmMemory,
     },
     kv::{
         mdbx::*,
@@ -176,6 +177,7 @@ where
     };
 
     let beneficiary = engine_factory(None, chain_spec.clone(), None)?.get_beneficiary(&header);
+    let mut mem = EvmMemory::new();
 
     for (transaction_index, (transaction, sender)) in messages.into_iter().zip(senders).enumerate()
     {
@@ -190,6 +192,7 @@ where
             &transaction.message,
             sender,
             beneficiary,
+            &mut mem,
         )?
         .1;
 
@@ -447,6 +450,7 @@ where
                 let mut engine = engine_factory(None, chain_spec, None)?;
                 let mut analysis_cache = AnalysisCache::default();
                 let mut tracer = NoopTracer;
+                let mut mem = EvmMemory::new();
 
                 let mut processor = ExecutionProcessor::new(
                     &mut buffer,
@@ -456,6 +460,7 @@ where
                     &header,
                     &block_body,
                     &block_execution_spec,
+                    &mut mem,
                 );
 
                 let transaction_index = chain::block_body::read_without_senders(&txn, block_hash, block_number)?.ok_or_else(|| format_err!("where's block body"))?.transactions

--- a/src/rpc/trace.rs
+++ b/src/rpc/trace.rs
@@ -4,6 +4,7 @@ use crate::{
     consensus::engine_factory,
     execution::{
         analysis_cache::AnalysisCache, processor::execute_transaction, tracer::adhoc::AdhocTracer,
+        EvmMemory,
     },
     kv::{mdbx::*, tables, MdbxWithDirHandle},
     models::*,
@@ -264,6 +265,7 @@ where
     let engine = engine_factory(None, chain_spec.clone(), None)?;
 
     let mut analysis_cache = AnalysisCache::default();
+    let mut mem = EvmMemory::new();
     for (sender, message, trace_types) in calls {
         let (output, updates, trace) = {
             let mut buffer = LoggingBuffer::new(&mut buffer);
@@ -282,6 +284,7 @@ where
                 &message,
                 sender,
                 engine.get_beneficiary(&header),
+                &mut mem,
             )?;
 
             state.write_to_state_same_block()?;

--- a/src/stages/execution.rs
+++ b/src/stages/execution.rs
@@ -5,6 +5,7 @@ use crate::{
         analysis_cache::AnalysisCache,
         processor::ExecutionProcessor,
         tracer::{CallTracer, CallTracerFlags},
+        EvmMemory,
     },
     h256_to_u256,
     kv::{
@@ -64,6 +65,7 @@ fn execute_batch_of_blocks<E: EnvironmentKind>(
         .unwrap();
     let mut last_message = Instant::now();
     let mut printed_at_least_once = false;
+    let mut mem = EvmMemory::new();
     loop {
         let block_hash = tx
             .get(tables::CanonicalHeader, block_number)?
@@ -91,6 +93,7 @@ fn execute_batch_of_blocks<E: EnvironmentKind>(
             &header,
             &block,
             &block_spec,
+            &mut mem,
         )
         .execute_and_write_block()
         .map_err(|e| match e {

--- a/src/stages/hashstate.rs
+++ b/src/stages/hashstate.rs
@@ -342,10 +342,11 @@ mod tests {
 
         buffer.update_account(sender, None, Some(sender_account));
 
+        let mut mem = EvmMemory::new();
         // ---------------------------------------
         // Execute first block
         // ---------------------------------------
-        execute_block(&mut buffer, &MAINNET, &header, &body).unwrap();
+        execute_block(&mut buffer, &MAINNET, &header, &body, &mut mem).unwrap();
 
         gas += header.gas_used;
         tx.set(tables::TotalGas, header.number, gas).unwrap();
@@ -370,7 +371,7 @@ mod tests {
             new_val.to_vec().into(),
         )];
 
-        execute_block(&mut buffer, &MAINNET.clone(), &header, &body).unwrap();
+        execute_block(&mut buffer, &MAINNET.clone(), &header, &body, &mut mem).unwrap();
 
         gas += header.gas_used;
         tx.set(tables::TotalGas, header.number, gas).unwrap();
@@ -393,7 +394,7 @@ mod tests {
             u256_to_h256(new_val.as_u256()).0.to_vec().into(),
         )];
 
-        execute_block(&mut buffer, &MAINNET.clone(), &header, &body).unwrap();
+        execute_block(&mut buffer, &MAINNET.clone(), &header, &body, &mut mem).unwrap();
 
         buffer.write_to_db().unwrap();
 


### PR DESCRIPTION
This PR reworks how EVM stack and memory is handled. The code allocates a big memory chunk (1 GiB) of virtual memory using `mmap`. Note that virtual memory is not the same as physically used one. We do not populate the virtual memory on creation, so OS provides physical memory pages only on first page use.

First 32 MiB of the mapped memory are used for EVM stack, while everything else is used for EVM memory. The allocated memory gets reused between contract executions, which reduces number of allocations and allows to reduce size of thread stack size.