### PR TITLE
Prepare code for memory reuse in EVM interpreter

### DIFF
--- a/bin/akula.rs
+++ b/bin/akula.rs
@@ -2,6 +2,7 @@ use akula::{
     akula_tracing::{self, Component},
     binutil::AkulaDataDir,
     consensus::{engine_factory, Consensus, ForkChoiceMode},
+    execution::EvmMemory,
     kv::tables::CHAINDATA_TABLES,
     models::*,
     p2p::node::NodeBuilder,
@@ -135,6 +136,8 @@ fn main() -> anyhow::Result<()> {
 
             rt.block_on(async move {
                 info!("Starting Akula ({})", version_string());
+
+                let mem = EvmMemory::new();
 
                 let mut bundled_chain_spec = false;
                 let chain_config = if let Some(chain) = opt.chain {
@@ -422,6 +425,7 @@ fn main() -> anyhow::Result<()> {
                         exit_after_batch: opt.execution_exit_after_batch,
                         batch_until: None,
                         commit_every: None,
+                        mem,
                     },
                     false,
                 );

--- a/src/consensus/blockchain.rs
+++ b/src/consensus/blockchain.rs
@@ -1,6 +1,8 @@
 use crate::{
     consensus::*,
-    execution::{analysis_cache::AnalysisCache, processor::ExecutionProcessor, tracer::NoopTracer},
+    execution::{
+        analysis_cache::AnalysisCache, processor::ExecutionProcessor, tracer::NoopTracer, EvmMemory,
+    },
     models::*,
     state::*,
 };
@@ -14,6 +16,7 @@ pub struct Blockchain<'state> {
     engine: Box<dyn Consensus>,
     bad_blocks: HashMap<H256, ValidationError>,
     receipts: Vec<Receipt>,
+    mem: EvmMemory,
 }
 
 impl<'state> Blockchain<'state> {
@@ -47,6 +50,7 @@ impl<'state> Blockchain<'state> {
             config,
             bad_blocks: Default::default(),
             receipts: Default::default(),
+            mem: EvmMemory::new(),
         })
     }
 
@@ -154,6 +158,7 @@ impl<'state> Blockchain<'state> {
             &block.header,
             &body,
             &block_spec,
+            &mut self.mem,
         );
 
         let _ = processor.execute_and_write_block()?;

--- a/src/execution/evm/benches/bench.rs
+++ b/src/execution/evm/benches/bench.rs
@@ -2,7 +2,7 @@ use akula::{
     execution::evm::{
         instructions::{instruction_table::get_instruction_table, PROPERTIES},
         util::{mocked_host::MockedHost, Bytecode},
-        AnalyzedCode, CallKind, InterpreterMessage, OpCode, Output, StatusCode,
+        AnalyzedCode, CallKind, EvmMemory, InterpreterMessage, OpCode, Output, StatusCode,
     },
     models::Revision,
 };
@@ -324,9 +324,15 @@ fn generate_code(params: &CodeParams) -> Bytecode {
 
 #[inline]
 fn execute(
-    (code, mut host, msg, rev): (AnalyzedCode, MockedHost, InterpreterMessage, Revision),
+    (code, mut host, msg, rev, mut mem): (
+        AnalyzedCode,
+        MockedHost,
+        InterpreterMessage,
+        Revision,
+        EvmMemory,
+    ),
 ) -> Output {
-    code.execute(&mut host, &msg, rev)
+    code.execute(&mut host, &msg, rev, mem.get_origin())
 }
 
 fn synthetic_benchmarks(c: &mut Criterion) {
@@ -461,7 +467,13 @@ fn synthetic_benchmarks(c: &mut Criterion) {
 fn prepare(
     code: AnalyzedCode,
     input_data: Bytes,
-) -> (AnalyzedCode, MockedHost, InterpreterMessage, Revision) {
+) -> (
+    AnalyzedCode,
+    MockedHost,
+    InterpreterMessage,
+    Revision,
+    EvmMemory,
+) {
     get_instruction_table(Revision::Istanbul);
     (
         code,
@@ -479,6 +491,7 @@ fn prepare(
             value: U256::ZERO,
         },
         Revision::Istanbul,
+        EvmMemory::new(),
     )
 }
 

--- a/src/execution/evm/host.rs
+++ b/src/execution/evm/host.rs
@@ -1,4 +1,7 @@
-use crate::execution::tracer::{NoopTracer, Tracer};
+use crate::execution::{
+    evm::EvmSubMemory,
+    tracer::{NoopTracer, Tracer},
+};
 
 use super::{
     common::{InterpreterMessage, Output},
@@ -99,7 +102,7 @@ pub trait Host {
     /// Self-destruct account.
     fn selfdestruct(&mut self, address: Address, beneficiary: Address);
     /// Call to another account.
-    fn call(&mut self, msg: Call) -> Output;
+    fn call(&mut self, msg: Call, mem: EvmSubMemory) -> Output;
     /// Retrieve transaction context.
     fn get_tx_context(&mut self) -> Result<TxContext, StatusCode>;
     /// Get block hash.

--- a/src/execution/evm/instructions/arithmetic.rs
+++ b/src/execution/evm/instructions/arithmetic.rs
@@ -7,35 +7,35 @@ use ethnum::U256;
 use i256::{i256_div, i256_mod};
 
 #[inline]
-pub(crate) fn add(stack: &mut Stack) {
+pub(crate) fn add(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.pop();
     stack.push(a.overflowing_add(b).0);
 }
 
 #[inline]
-pub(crate) fn mul(stack: &mut Stack) {
+pub(crate) fn mul(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.pop();
     stack.push(a.overflowing_mul(b).0);
 }
 
 #[inline]
-pub(crate) fn sub(stack: &mut Stack) {
+pub(crate) fn sub(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.pop();
     stack.push(a.overflowing_sub(b).0);
 }
 
 #[inline]
-pub(crate) fn div(stack: &mut Stack) {
+pub(crate) fn div(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
     *b = if *b == 0 { U256::ZERO } else { a / *b };
 }
 
 #[inline]
-pub(crate) fn sdiv(stack: &mut Stack) {
+pub(crate) fn sdiv(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.pop();
     let v = i256_div(a, b);
@@ -43,14 +43,14 @@ pub(crate) fn sdiv(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn modulo(stack: &mut Stack) {
+pub(crate) fn modulo(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
     *b = if *b == 0 { U256::ZERO } else { a % *b };
 }
 
 #[inline]
-pub(crate) fn smod(stack: &mut Stack) {
+pub(crate) fn smod(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
 
@@ -62,7 +62,7 @@ pub(crate) fn smod(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn addmod(stack: &mut Stack) {
+pub(crate) fn addmod(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.pop();
     let c = stack.pop();
@@ -84,7 +84,7 @@ pub(crate) fn addmod(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn mulmod(stack: &mut Stack) {
+pub(crate) fn mulmod(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.pop();
     let c = stack.pop();
@@ -126,8 +126,8 @@ fn log2floor(value: U256) -> u64 {
 
 #[inline]
 pub(crate) fn exp<const REVISION: Revision>(state: &mut ExecutionState) -> Result<(), StatusCode> {
-    let mut base = state.stack.pop();
-    let mut power = state.stack.pop();
+    let mut base = state.stack().pop();
+    let mut power = state.stack().pop();
 
     if power > 0 {
         let factor = if REVISION >= Revision::Spurious {
@@ -154,13 +154,13 @@ pub(crate) fn exp<const REVISION: Revision>(state: &mut ExecutionState) -> Resul
         base = base.overflowing_mul(base).0;
     }
 
-    state.stack.push(v);
+    state.stack().push(v);
 
     Ok(())
 }
 
 #[inline]
-pub(crate) fn signextend(stack: &mut Stack) {
+pub(crate) fn signextend(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
 

--- a/src/execution/evm/instructions/bitwise.rs
+++ b/src/execution/evm/instructions/bitwise.rs
@@ -1,9 +1,9 @@
-use crate::execution::evm::state::Stack;
+use crate::execution::evm::state::EvmStack;
 use ethnum::U256;
 use i256::{i256_sign, two_compl, Sign};
 
 #[inline]
-pub(crate) fn byte(stack: &mut Stack) {
+pub(crate) fn byte(stack: &mut EvmStack) {
     let i = stack.pop();
     let x = stack.get_mut(0);
 
@@ -25,7 +25,7 @@ pub(crate) fn byte(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn shl(stack: &mut Stack) {
+pub(crate) fn shl(stack: &mut EvmStack) {
     let shift = stack.pop();
     let value = stack.get_mut(0);
 
@@ -37,7 +37,7 @@ pub(crate) fn shl(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn shr(stack: &mut Stack) {
+pub(crate) fn shr(stack: &mut EvmStack) {
     let shift = stack.pop();
     let value = stack.get_mut(0);
 
@@ -49,7 +49,7 @@ pub(crate) fn shr(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn sar(stack: &mut Stack) {
+pub(crate) fn sar(stack: &mut EvmStack) {
     let shift = stack.pop();
     let mut value = stack.pop();
 
@@ -80,6 +80,7 @@ pub(crate) fn sar(stack: &mut Stack) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::execution::evm::state::EvmMemory;
 
     #[test]
     fn test_instruction_byte() {
@@ -91,8 +92,11 @@ mod tests {
                 .unwrap(),
         );
 
+        let mut evm_mem = EvmMemory::new();
+        let mut mem = evm_mem.get_origin();
+
         for i in 0u16..32 {
-            let mut stack = Stack::new();
+            let mut stack = mem.stack();
             stack.push(value);
             stack.push(U256::from(i));
 
@@ -102,7 +106,8 @@ mod tests {
             assert_eq!(result, U256::from(5 * (i + 1)));
         }
 
-        let mut stack = Stack::new();
+        let mut mem = mem.next_submem();
+        let mut stack = mem.stack();
         stack.push(value);
         stack.push(U256::from(100u128));
 
@@ -110,7 +115,8 @@ mod tests {
         let result = stack.pop();
         assert_eq!(result, U256::ZERO);
 
-        let mut stack = Stack::new();
+        let mut mem = mem.next_submem();
+        let mut stack = mem.stack();
         stack.push(value);
         stack.push(U256::from_words(1, 0));
 

--- a/src/execution/evm/instructions/boolean.rs
+++ b/src/execution/evm/instructions/boolean.rs
@@ -4,7 +4,7 @@ use i256::i256_cmp;
 use std::cmp::Ordering;
 
 #[inline]
-pub(crate) fn lt(stack: &mut Stack) {
+pub(crate) fn lt(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
 
@@ -12,7 +12,7 @@ pub(crate) fn lt(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn gt(stack: &mut Stack) {
+pub(crate) fn gt(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
 
@@ -20,7 +20,7 @@ pub(crate) fn gt(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn slt(stack: &mut Stack) {
+pub(crate) fn slt(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
 
@@ -32,7 +32,7 @@ pub(crate) fn slt(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn sgt(stack: &mut Stack) {
+pub(crate) fn sgt(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
 
@@ -44,7 +44,7 @@ pub(crate) fn sgt(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn eq(stack: &mut Stack) {
+pub(crate) fn eq(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
 
@@ -52,34 +52,34 @@ pub(crate) fn eq(stack: &mut Stack) {
 }
 
 #[inline]
-pub(crate) fn iszero(stack: &mut Stack) {
+pub(crate) fn iszero(stack: &mut EvmStack) {
     let a = stack.get_mut(0);
     *a = if *a == 0 { U256::ONE } else { U256::ZERO }
 }
 
 #[inline]
-pub(crate) fn and(stack: &mut Stack) {
+pub(crate) fn and(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
     *b = a & *b;
 }
 
 #[inline]
-pub(crate) fn or(stack: &mut Stack) {
+pub(crate) fn or(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
     *b = a | *b;
 }
 
 #[inline]
-pub(crate) fn xor(stack: &mut Stack) {
+pub(crate) fn xor(stack: &mut EvmStack) {
     let a = stack.pop();
     let b = stack.get_mut(0);
     *b = a ^ *b;
 }
 
 #[inline]
-pub(crate) fn not(stack: &mut Stack) {
+pub(crate) fn not(stack: &mut EvmStack) {
     let v = stack.get_mut(0);
     *v = !*v;
 }

--- a/src/execution/evm/instructions/control.rs
+++ b/src/execution/evm/instructions/control.rs
@@ -3,13 +3,13 @@ use ethnum::U256;
 
 #[inline]
 pub(crate) fn ret(state: &mut ExecutionState) -> Result<(), StatusCode> {
-    let offset = *state.stack.get(0);
-    let size = *state.stack.get(1);
+    let offset = *state.stack().get(0);
+    let size = *state.stack().get(1);
 
     if let Some(region) = super::memory::get_memory_region(state, offset, size)? {
         let offset = region.offset;
         let size = region.size.get();
-        state.output_data = state.memory[offset..][..size].to_vec().into();
+        state.output_data = state.heap()[offset..][..size].to_vec().into();
     }
 
     Ok(())
@@ -25,7 +25,7 @@ pub(crate) fn op_jump(dst: U256, jumpdest_map: &JumpdestMap) -> Result<usize, St
 
 #[inline]
 pub(crate) fn calldataload(state: &mut ExecutionState) {
-    let index = state.stack.pop();
+    let index = state.stack().pop();
 
     let input_len = state.message.input_data.len();
 
@@ -40,7 +40,7 @@ pub(crate) fn calldataload(state: &mut ExecutionState) {
 
         U256::from_be_bytes(data)
     };
-    state.stack.push(res);
+    state.stack().push(res);
 }
 
 #[inline]
@@ -48,5 +48,5 @@ pub(crate) fn calldatasize(state: &mut ExecutionState) {
     let res = u128::try_from(state.message.input_data.len())
         .unwrap()
         .into();
-    state.stack.push(res);
+    state.stack().push(res);
 }

--- a/src/execution/evm/instructions/external.rs
+++ b/src/execution/evm/instructions/external.rs
@@ -15,19 +15,19 @@ fn ok_or_out_of_gas(gas_left: i64) -> Result<(), StatusCode> {
 #[inline]
 pub(crate) fn address(state: &mut ExecutionState) {
     let res = address_to_u256(state.message.recipient);
-    state.stack.push(res);
+    state.stack().push(res);
 }
 
 #[inline]
 pub(crate) fn caller(state: &mut ExecutionState) {
     let res = address_to_u256(state.message.sender);
-    state.stack.push(res);
+    state.stack().push(res);
 }
 
 #[inline]
 pub(crate) fn callvalue(state: &mut ExecutionState) {
     let res = state.message.value;
-    state.stack.push(res);
+    state.stack().push(res);
 }
 
 #[inline]
@@ -41,14 +41,14 @@ pub(crate) fn balance<H: Host, const REVISION: Revision>(
         models::*,
     };
 
-    let address = u256_to_address(state.stack.pop());
+    let address = u256_to_address(state.stack().pop());
 
     let is_cold =
         REVISION >= Revision::Berlin && host.access_account(address) == AccessStatus::Cold;
     let additional_cost = is_cold as i64 * ADDITIONAL_COLD_ACCOUNT_ACCESS_COST as i64;
     state.gas_left -= additional_cost;
 
-    state.stack.push(host.get_balance(address));
+    state.stack().push(host.get_balance(address));
 
     ok_or_out_of_gas(state.gas_left)
 }
@@ -64,13 +64,13 @@ pub(crate) fn extcodesize<H: Host, const REVISION: Revision>(
         models::*,
     };
 
-    let address = u256_to_address(state.stack.pop());
+    let address = u256_to_address(state.stack().pop());
 
     let is_cold =
         REVISION >= Revision::Berlin && host.access_account(address) == AccessStatus::Cold;
     let additional_cost = is_cold as i64 * ADDITIONAL_COLD_ACCOUNT_ACCESS_COST as i64;
 
-    state.stack.push(host.get_code_size(address));
+    state.stack().push(host.get_code_size(address));
     state.gas_left -= additional_cost;
 
     ok_or_out_of_gas(state.gas_left)
@@ -123,7 +123,8 @@ pub(crate) fn basefee_accessor(tx_context: TxContext) -> U256 {
 
 #[inline]
 pub(crate) fn selfbalance<H: Host>(state: &mut ExecutionState, host: &mut H) {
-    state.stack.push(host.get_balance(state.message.recipient));
+    let res = host.get_balance(state.message.recipient);
+    state.stack().push(res);
 }
 
 #[inline]
@@ -131,7 +132,7 @@ pub(crate) fn blockhash<H: Host>(
     state: &mut ExecutionState,
     host: &mut H,
 ) -> Result<(), StatusCode> {
-    let number = state.stack.pop();
+    let number = state.stack().pop();
 
     let upper_bound = host.get_tx_context()?.block_number;
     let lower_bound = upper_bound.saturating_sub(256);
@@ -144,7 +145,7 @@ pub(crate) fn blockhash<H: Host>(
         }
     }
 
-    state.stack.push(header);
+    state.stack().push(header);
 
     Ok(())
 }
@@ -159,8 +160,8 @@ pub(crate) fn do_log<H: Host, const NUM_TOPICS: usize>(
         return Err(StatusCode::StaticModeViolation);
     }
 
-    let offset = state.stack.pop();
-    let size = state.stack.pop();
+    let offset = state.stack().pop();
+    let size = state.stack().pop();
 
     let region = memory::get_memory_region(state, offset, size)?;
 
@@ -172,14 +173,15 @@ pub(crate) fn do_log<H: Host, const NUM_TOPICS: usize>(
         }
     }
 
-    let topics = [(); NUM_TOPICS].map(|()| state.stack.pop());
+    let topics = [(); NUM_TOPICS].map(|()| state.stack().pop());
+    let heap = state.heap();
     let data = if let Some(region) = region {
-        &state.memory[region.offset..][..region.size.get()]
+        heap[region.offset..][..region.size.get()].to_vec()
     } else {
-        &[]
+        Vec::new()
     };
 
-    host.emit_log(state.message.recipient, data.to_vec().into(), &topics);
+    host.emit_log(state.message.recipient, data.into(), &topics);
 
     Ok(())
 }
@@ -198,16 +200,15 @@ pub(crate) fn sload<H: Host, const REVISION: Revision>(
         models::*,
     };
 
-    let location = state.stack.pop();
+    let location = state.stack().pop();
 
     const ADDITIONAL_COLD_SLOAD_COST: u16 = COLD_SLOAD_COST - WARM_STORAGE_READ_COST;
     let is_cold = REVISION >= Revision::Berlin
         && host.access_storage(state.message.recipient, location) == AccessStatus::Cold;
     let additional_cost = is_cold as i64 * ADDITIONAL_COLD_SLOAD_COST as i64;
 
-    state
-        .stack
-        .push(host.get_storage(state.message.recipient, location));
+    let res = host.get_storage(state.message.recipient, location);
+    state.stack().push(res);
 
     state.gas_left -= additional_cost;
     ok_or_out_of_gas(state.gas_left)
@@ -237,8 +238,8 @@ pub(crate) fn sstore<H: Host, const REVISION: Revision>(
         }
     }
 
-    let location = state.stack.pop();
-    let value = state.stack.pop();
+    let location = state.stack().pop();
+    let value = state.stack().pop();
 
     let mut cost = 0;
     if REVISION >= Revision::Berlin {
@@ -288,7 +289,7 @@ pub(crate) fn selfdestruct<H: Host, const REVISION: Revision>(
         return Err(StatusCode::StaticModeViolation);
     }
 
-    let beneficiary = u256_to_address(state.stack.pop());
+    let beneficiary = u256_to_address(state.stack().pop());
 
     let is_cold =
         REVISION >= Revision::Berlin && host.access_account(beneficiary) == AccessStatus::Cold;

--- a/src/execution/evm/instructions/stack_manip.rs
+++ b/src/execution/evm/instructions/stack_manip.rs
@@ -1,9 +1,9 @@
-use crate::execution::evm::{common::*, state::Stack, AnalyzedCode};
+use crate::execution::evm::{common::*, state::EvmStack, AnalyzedCode};
 use arrayref::array_ref;
 use ethnum::U256;
 
 #[inline(always)]
-pub(crate) fn push<const LEN: usize>(stack: &mut Stack, s: &AnalyzedCode, pc: usize) -> usize {
+pub(crate) fn push<const LEN: usize>(stack: &mut EvmStack, s: &AnalyzedCode, pc: usize) -> usize {
     let code = &s.padded_code()[pc + 1..];
     match LEN {
         1 => stack.push(code[0].into()),
@@ -15,16 +15,16 @@ pub(crate) fn push<const LEN: usize>(stack: &mut Stack, s: &AnalyzedCode, pc: us
 }
 
 #[inline]
-pub(crate) fn dup<const HEIGHT: usize>(stack: &mut Stack) {
+pub(crate) fn dup<const HEIGHT: usize>(stack: &mut EvmStack) {
     stack.push(*stack.get(HEIGHT - 1));
 }
 
 #[inline]
-pub(crate) fn swap<const HEIGHT: usize>(stack: &mut Stack) {
+pub(crate) fn swap<const HEIGHT: usize>(stack: &mut EvmStack) {
     stack.swap_top(HEIGHT);
 }
 
 #[inline]
-pub(crate) fn pop(stack: &mut Stack) {
+pub(crate) fn pop(stack: &mut EvmStack) {
     stack.pop();
 }

--- a/src/execution/evm/interpreter.rs
+++ b/src/execution/evm/interpreter.rs
@@ -20,7 +20,7 @@ fn check_requirements(
         return Err(StatusCode::OutOfGas);
     }
 
-    let stack_size = state.stack.len();
+    let stack_size = state.stack().len();
     if stack_size == STACK_SIZE {
         if metrics.can_overflow_stack {
             return Err(StatusCode::StackOverflow);
@@ -101,11 +101,12 @@ impl AnalyzedCode {
         host: &mut H,
         message: &InterpreterMessage,
         revision: Revision,
+        mem: EvmSubMemory,
     ) -> Output
     where
         H: Host,
     {
-        let mut state = ExecutionState::new(message);
+        let mut state = ExecutionState::new(message, mem);
 
         macro_rules! execute_revisions {
             (
@@ -207,7 +208,7 @@ where
 
         check_requirements(metrics, state)?;
 
-        let stack = &mut state.stack;
+        let stack = &mut state.mem.stack();
         match op {
             OpCode::STOP => break false,
             OpCode::ADD => arithmetic::add(stack),

--- a/src/execution/evm/mod.rs
+++ b/src/execution/evm/mod.rs
@@ -5,7 +5,7 @@ pub use common::{
 pub use host::Host;
 pub use interpreter::AnalyzedCode;
 pub use opcode::OpCode;
-pub use state::{ExecutionState, Stack};
+pub use state::{EvmMemory, EvmStack, EvmSubMemory, ExecutionState};
 
 /// Maximum allowed EVM bytecode size.
 pub const MAX_CODE_SIZE: usize = 0x6000;

--- a/src/execution/evm/state.rs
+++ b/src/execution/evm/state.rs
@@ -1,44 +1,103 @@
 use super::common::InterpreterMessage;
-use arrayvec::ArrayVec;
-use bytes::{Bytes, BytesMut};
-use derive_more::{Deref, DerefMut};
+use bytes::Bytes;
 use ethnum::U256;
 use getset::{Getters, MutGetters};
-use serde::Serialize;
+use std::{
+    hint::unreachable_unchecked,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
 
 pub const STACK_SIZE: usize = 1024;
 pub const MAX_CONTEXT_DEPTH: usize = 1024;
+const PAGE_SIZE: usize = 4 * 1024;
 
-/// EVM stack.
-#[derive(Clone, Debug, Default, Serialize)]
-pub struct Stack(pub ArrayVec<U256, STACK_SIZE>);
+#[derive(Debug)]
+pub struct EvmMemory {}
 
-impl Stack {
-    #[inline]
-    pub const fn new() -> Self {
-        Self(ArrayVec::new_const())
+impl EvmMemory {
+    #[inline(always)]
+    pub fn new() -> Self {
+        Self {}
     }
 
+    #[inline(always)]
+    pub fn get_origin(&mut self) -> EvmSubMemory {
+        EvmSubMemory {
+            heap: Vec::with_capacity(PAGE_SIZE),
+            stack: Vec::with_capacity(STACK_SIZE),
+            origin: PhantomData,
+        }
+    }
+}
+
+impl Default for EvmMemory {
+    #[inline(always)]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct EvmSubMemory<'a> {
+    heap: Vec<u8>,
+    stack: Vec<U256>,
+    origin: PhantomData<&'a mut ()>,
+}
+
+impl<'a> EvmSubMemory<'a> {
+    #[inline(always)]
+    pub fn next_submem(&mut self) -> Self {
+        Self {
+            heap: Vec::with_capacity(PAGE_SIZE),
+            stack: Vec::with_capacity(STACK_SIZE),
+            origin: self.origin,
+        }
+    }
+
+    #[inline(always)]
+    pub fn stack<'b>(&'b mut self) -> EvmStack<'b, 'a> {
+        EvmStack {
+            stack: &mut self.stack,
+            origin: self.origin,
+        }
+    }
+
+    #[inline(always)]
+    pub fn heap<'b>(&'b mut self) -> EvmHeap<'b, 'a> {
+        EvmHeap {
+            heap: &mut self.heap,
+            origin: self.origin,
+        }
+    }
+}
+
+/// EVM stack.
+pub struct EvmStack<'a, 'b> {
+    stack: &'a mut Vec<U256>,
+    origin: PhantomData<&'b mut ()>,
+}
+
+impl<'a, 'b> EvmStack<'a, 'b> {
     #[inline]
-    const fn get_pos(&self, pos: usize) -> usize {
+    fn get_pos(&self, pos: usize) -> usize {
         self.len() - 1 - pos
     }
 
     #[inline]
     pub fn get(&self, pos: usize) -> &U256 {
         let pos = self.get_pos(pos);
-        unsafe { self.0.get_unchecked(pos) }
+        unsafe { self.stack.get_unchecked(pos) }
     }
 
     #[inline]
     pub fn get_mut(&mut self, pos: usize) -> &mut U256 {
         let pos = self.get_pos(pos);
-        unsafe { self.0.get_unchecked_mut(pos) }
+        unsafe { self.stack.get_unchecked_mut(pos) }
     }
 
     #[inline(always)]
-    pub const fn len(&self) -> usize {
-        self.0.len()
+    pub fn len(&self) -> usize {
+        self.stack.len()
     }
 
     #[inline(always)]
@@ -48,77 +107,108 @@ impl Stack {
 
     #[inline]
     pub fn push(&mut self, v: U256) {
-        unsafe { self.0.push_unchecked(v) }
+        // Prevent branch which resizes vector
+        if self.stack.len() == self.stack.capacity() {
+            debug_assert!(false);
+            unsafe { unreachable_unchecked() }
+        }
+        self.stack.push(v)
     }
 
     #[inline]
     pub fn pop(&mut self) -> U256 {
-        unsafe { self.0.pop_unchecked() }
+        self.stack.pop().unwrap_or_else(|| unsafe {
+            debug_assert!(false);
+            unreachable_unchecked()
+        })
     }
 
     #[inline]
     pub fn swap_top(&mut self, pos: usize) {
-        let top = self.0.len() - 1;
+        let top = self.stack.len() - 1;
         let pos = self.get_pos(pos);
         unsafe {
-            self.0.swap_unchecked(top, pos);
+            self.stack.swap_unchecked(top, pos);
         }
     }
 }
 
-const PAGE_SIZE: usize = 4 * 1024;
+pub struct EvmHeap<'a, 'b> {
+    heap: &'a mut Vec<u8>,
+    origin: PhantomData<&'b mut ()>,
+}
 
-#[derive(Clone, Debug, Deref, DerefMut)]
-pub struct Memory(BytesMut);
-
-impl Memory {
-    #[inline]
-    pub fn new() -> Self {
-        Self(BytesMut::with_capacity(PAGE_SIZE))
+impl<'a, 'b> EvmHeap<'a, 'b> {
+    /// Get size of stack in `u8`s.
+    #[inline(always)]
+    fn size(&self) -> usize {
+        self.heap.len()
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn grow(&mut self, size: usize) {
-        let cap = self.0.capacity();
-        if size > cap {
-            let required_pages = (size + PAGE_SIZE - 1) / PAGE_SIZE;
-            self.0.reserve((PAGE_SIZE * required_pages) - self.0.len());
-        }
-        self.0.resize(size, 0);
+        self.heap.resize(size, 0)
     }
 }
 
-impl Default for Memory {
-    fn default() -> Self {
-        Self::new()
+impl<'a, 'b> Deref for EvmHeap<'a, 'b> {
+    type Target = [u8];
+
+    #[inline(always)]
+    fn deref(&self) -> &[u8] {
+        self.heap
+    }
+}
+
+impl<'a, 'b> DerefMut for EvmHeap<'a, 'b> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut [u8] {
+        self.heap
     }
 }
 
 /// EVM execution state.
-#[derive(Clone, Debug, Getters, MutGetters)]
-pub struct ExecutionState<'m> {
+#[derive(Getters, MutGetters)]
+pub struct ExecutionState<'a> {
     #[getset(get = "pub", get_mut = "pub")]
     pub(crate) gas_left: i64,
     #[getset(get = "pub", get_mut = "pub")]
-    pub(crate) stack: Stack,
-    #[getset(get = "pub", get_mut = "pub")]
-    pub(crate) memory: Memory,
-    pub(crate) message: &'m InterpreterMessage,
+    pub(crate) mem: EvmSubMemory<'a>,
+    pub(crate) message: &'a InterpreterMessage,
     #[getset(get = "pub", get_mut = "pub")]
     pub(crate) return_data: Bytes,
     pub(crate) output_data: Bytes,
 }
 
-impl<'m> ExecutionState<'m> {
-    pub fn new(message: &'m InterpreterMessage) -> Self {
+impl<'a> ExecutionState<'a> {
+    pub fn new(message: &'a InterpreterMessage, mem: EvmSubMemory<'a>) -> Self {
         Self {
             gas_left: message.gas,
-            stack: Stack::default(),
-            memory: Memory::new(),
+            mem,
             message,
             return_data: Default::default(),
             output_data: Bytes::new(),
         }
+    }
+
+    #[inline(always)]
+    pub fn stack<'b>(&'b mut self) -> EvmStack<'b, 'a> {
+        self.mem.stack()
+    }
+
+    #[inline(always)]
+    pub fn heap<'b>(&'b mut self) -> EvmHeap<'b, 'a> {
+        self.mem.heap()
+    }
+
+    #[inline(always)]
+    pub fn clone_stack_to_vec(&self) -> Vec<U256> {
+        self.mem.stack.clone()
+    }
+
+    #[inline(always)]
+    pub fn heap_size(&self) -> usize {
+        self.mem.heap.len()
     }
 }
 
@@ -128,7 +218,9 @@ mod tests {
 
     #[test]
     fn stack() {
-        let mut stack = Stack::default();
+        let mut evm_mem = EvmMemory::new();
+        let mut mem = evm_mem.get_origin();
+        let mut stack = mem.stack();
 
         let items: [u128; 4] = [0xde, 0xad, 0xbe, 0xef];
 
@@ -146,9 +238,15 @@ mod tests {
 
     #[test]
     fn grow() {
-        let mut mem = Memory::new();
-        mem.grow(PAGE_SIZE * 2 + 1);
-        assert_eq!(mem.len(), PAGE_SIZE * 2 + 1);
-        assert_eq!(mem.capacity(), PAGE_SIZE * 3);
+        const LEN: usize = 10_000;
+        let mut evm_mem = EvmMemory::new();
+        let mut mem = evm_mem.get_origin();
+        let mut heap = mem.heap();
+        heap.grow(LEN);
+        for val in heap.iter_mut() {
+            *val = 42;
+        }
+        assert!(heap.iter().all(|val| *val == 42));
+        assert_eq!(heap.len(), LEN);
     }
 }

--- a/src/execution/evm/util/mocked_host.rs
+++ b/src/execution/evm/util/mocked_host.rs
@@ -227,7 +227,7 @@ impl Host for MockedHost {
         });
     }
 
-    fn call(&mut self, msg: Call) -> Output {
+    fn call(&mut self, msg: Call, _stack: EvmSubMemory) -> Output {
         let msg = match msg {
             Call::Call(message) => message.clone(),
             Call::Create(message) => message.clone().into(),

--- a/src/execution/evm/util/tester.rs
+++ b/src/execution/evm/util/tester.rs
@@ -24,7 +24,10 @@ fn exec(
     }
     let code = AnalyzedCode::analyze(&code);
 
-    code.execute(host, &message, revision)
+    let mut evm_mem = EvmMemory::new();
+    let mem = evm_mem.get_origin();
+
+    code.execute(host, &message, revision, mem)
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -13,11 +13,14 @@ pub mod precompiled;
 pub mod processor;
 pub mod tracer;
 
+pub use evm::EvmMemory;
+
 pub fn execute_block<S: State>(
     state: &mut S,
     config: &ChainSpec,
     header: &BlockHeader,
     block: &BlockBodyWithSenders,
+    mem: &mut EvmMemory,
 ) -> Result<Vec<Receipt>, DuoError> {
     let mut analysis_cache = AnalysisCache::default();
     let mut engine = consensus::engine_factory(None, config.clone(), None)?;
@@ -32,6 +35,7 @@ pub fn execute_block<S: State>(
         header,
         block,
         &config,
+        mem,
     )
     .execute_and_write_block()
 }
@@ -133,6 +137,7 @@ mod tests {
         let tx = (t)(TransactionAction::Create, deployment_code.into(), 0, 0);
 
         let mut state = InMemoryState::default();
+        let mut mem = EvmMemory::new();
         let sender_account = Account {
             balance: ETHER.into(),
             ..Default::default()
@@ -151,6 +156,7 @@ mod tests {
                 transactions: vec![tx],
                 ommers: Default::default(),
             },
+            &mut mem,
         )
         .unwrap();
 
@@ -202,6 +208,7 @@ mod tests {
                 transactions: vec![tx],
                 ommers: Default::default(),
             },
+            &mut mem,
         )
         .unwrap();
 

--- a/src/execution/tracer/eip3155_tracer.rs
+++ b/src/execution/tracer/eip3155_tracer.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    execution::evm::{ExecutionState, OpCode, Output, Stack, StatusCode},
+    execution::evm::{ExecutionState, OpCode, Output, StatusCode},
     models::*,
 };
 use bytes::Bytes;
@@ -21,7 +21,7 @@ pub(crate) struct InstructionStart {
     pub op: u8,
     pub op_name: &'static str,
     pub gas: u64,
-    pub stack: Stack,
+    pub stack: Vec<U256>,
     pub memory_size: usize,
 }
 
@@ -70,8 +70,8 @@ impl Tracer for StdoutTracer {
                 op: op.0,
                 op_name: op.name(),
                 gas: env.gas_left as u64,
-                stack: env.stack.clone(),
-                memory_size: env.memory.len()
+                stack: env.clone_stack_to_vec(),
+                memory_size: env.heap_size(),
             })
             .unwrap()
         )

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -13,6 +13,7 @@ pub mod helpers {
         consensus::{engine_factory, DuoError},
         execution::{
             analysis_cache::AnalysisCache, processor::ExecutionProcessor, tracer::NoopTracer,
+            EvmMemory,
         },
         kv::{mdbx::*, tables},
         models::*,
@@ -295,6 +296,8 @@ pub mod helpers {
         let mut analysis_cache = AnalysisCache::default();
         let mut tracer = NoopTracer;
 
+        // TODO: check if we can reuse EvmMemory
+        let mut mem = EvmMemory::new();
         let mut processor = ExecutionProcessor::new(
             &mut buffer,
             &mut tracer,
@@ -303,6 +306,7 @@ pub mod helpers {
             &header,
             &block_body,
             &block_execution_spec,
+            &mut mem,
         );
 
         processor

--- a/src/rpc/otterscan.rs
+++ b/src/rpc/otterscan.rs
@@ -6,6 +6,7 @@ use crate::{
         analysis_cache::AnalysisCache,
         processor::{execute_transaction, ExecutionProcessor},
         tracer::{CallKind, MessageKind, NoopTracer, Tracer},
+        EvmMemory,
     },
     kv::{
         mdbx::*,
@@ -172,6 +173,7 @@ where
     };
 
     let beneficiary = engine_factory(None, chain_spec.clone(), None)?.get_beneficiary(&header);
+    let mut mem = EvmMemory::new();
 
     for (transaction_index, (transaction, sender)) in messages.into_iter().zip(senders).enumerate()
     {
@@ -186,6 +188,7 @@ where
             &transaction.message,
             sender,
             beneficiary,
+            &mut mem,
         )?
         .1;
 
@@ -443,6 +446,7 @@ where
                 let mut engine = engine_factory(None, chain_spec, None)?;
                 let mut analysis_cache = AnalysisCache::default();
                 let mut tracer = NoopTracer;
+                let mut mem = EvmMemory::new();
 
                 let mut processor = ExecutionProcessor::new(
                     &mut buffer,
@@ -452,6 +456,7 @@ where
                     &header,
                     &block_body,
                     &block_execution_spec,
+                    &mut mem,
                 );
 
                 let transaction_index = chain::block_body::read_without_senders(&txn, block_number)?.ok_or_else(|| format_err!("where's block body"))?.transactions

--- a/src/rpc/trace.rs
+++ b/src/rpc/trace.rs
@@ -4,6 +4,7 @@ use crate::{
     consensus::engine_factory,
     execution::{
         analysis_cache::AnalysisCache, processor::execute_transaction, tracer::adhoc::AdhocTracer,
+        EvmMemory,
     },
     kv::{mdbx::*, tables, MdbxWithDirHandle},
     models::*,
@@ -260,6 +261,7 @@ where
     let engine = engine_factory(None, chain_spec.clone(), None)?;
 
     let mut analysis_cache = AnalysisCache::default();
+    let mut mem = EvmMemory::new();
     for (sender, message, trace_types) in calls {
         let (output, updates, trace) = {
             let mut buffer = LoggingBuffer::new(&mut buffer);
@@ -278,6 +280,7 @@ where
                 &message,
                 sender,
                 engine.get_beneficiary(&header),
+                &mut mem,
             )?;
 
             state.write_to_state_same_block()?;

--- a/src/stages/hashstate.rs
+++ b/src/stages/hashstate.rs
@@ -342,10 +342,11 @@ mod tests {
 
         buffer.update_account(sender, None, Some(sender_account));
 
+        let mut mem = EvmMemory::new();
         // ---------------------------------------
         // Execute first block
         // ---------------------------------------
-        execute_block(&mut buffer, &MAINNET, &header, &body).unwrap();
+        execute_block(&mut buffer, &MAINNET, &header, &body, &mut mem).unwrap();
 
         gas += header.gas_used;
         tx.set(tables::TotalGas, header.number, gas).unwrap();
@@ -370,7 +371,7 @@ mod tests {
             new_val.to_vec().into(),
         )];
 
-        execute_block(&mut buffer, &MAINNET.clone(), &header, &body).unwrap();
+        execute_block(&mut buffer, &MAINNET.clone(), &header, &body, &mut mem).unwrap();
 
         gas += header.gas_used;
         tx.set(tables::TotalGas, header.number, gas).unwrap();
@@ -393,7 +394,7 @@ mod tests {
             u256_to_h256(new_val.as_u256()).0.to_vec().into(),
         )];
 
-        execute_block(&mut buffer, &MAINNET.clone(), &header, &body).unwrap();
+        execute_block(&mut buffer, &MAINNET.clone(), &header, &body, &mut mem).unwrap();
 
         buffer.write_to_db().unwrap();
 


### PR DESCRIPTION
This PR does not implement memory reuse, but only prepares ground for approaches implemented in #318 and #328.

Depends on #334.